### PR TITLE
fix: profile pause/unpause logic is inverted

### DIFF
--- a/frontend/src/routes/profiles/[id]/+page.svelte
+++ b/frontend/src/routes/profiles/[id]/+page.svelte
@@ -58,9 +58,10 @@
 			// Optimistic update
 			profile = { ...profile, paused: !profile.paused };
 
-			const result = action === 'pause'
-				? await api.profiles.pause(profileId)
-				: await api.profiles.unpause(profileId);
+			const result =
+				action === 'pause'
+					? await api.profiles.pause(profileId)
+					: await api.profiles.unpause(profileId);
 
 			if (result.success) {
 				uiStore.success(result.message || `Profile ${action}d successfully`);

--- a/frontend/src/routes/profiles/[id]/+page.svelte
+++ b/frontend/src/routes/profiles/[id]/+page.svelte
@@ -58,9 +58,9 @@
 			// Optimistic update
 			profile = { ...profile, paused: !profile.paused };
 
-			const result = profile.paused
-				? await api.profiles.unpause(profileId)
-				: await api.profiles.pause(profileId);
+			const result = action === 'pause'
+				? await api.profiles.pause(profileId)
+				: await api.profiles.unpause(profileId);
 
 			if (result.success) {
 				uiStore.success(result.message || `Profile ${action}d successfully`);


### PR DESCRIPTION
## Summary

- Fixes the profile pause/unpause button sending the wrong command (pause sent unpause and vice versa)
- Root cause: `profile.paused` was checked **after** the optimistic update had already flipped it, so the condition was inverted
- Fix: use the `action` variable captured **before** the optimistic update to determine which API endpoint to call

## Root Cause

```javascript
// Before (broken): profile.paused is already flipped by line 59
profile = { ...profile, paused: !profile.paused };  // optimistic update

const result = profile.paused                        // ← checks AFTER flip
    ? await api.profiles.unpause(profileId)           // ← inverted!
    : await api.profiles.pause(profileId);

// After (fixed): uses action captured BEFORE the optimistic update
const action = profile.paused ? 'unpause' : 'pause'; // ← captured before flip

profile = { ...profile, paused: !profile.paused };   // optimistic update

const result = action === 'pause'                     // ← uses pre-flip value
    ? await api.profiles.pause(profileId)
    : await api.profiles.unpause(profileId);
```

## Test plan

- [x] Existing frontend tests pass
- [ ] Manually verify: clicking "Pause" on an active profile sends the pause command
- [ ] Manually verify: clicking "Resume" on a paused profile sends the unpause command

Fixes #154