### PR TITLE
feat: profile CRUD + network rename (post eero-api 4.1.2 follow-up)

### DIFF
--- a/backend/app/routes/networks.py
+++ b/backend/app/routes/networks.py
@@ -112,6 +112,15 @@ class SpeedTestResult(BaseModel):
     timestamp: str | None = None
 
 
+class NetworkRenameRequest(BaseModel):
+    """Request body for renaming a network."""
+
+    name: str
+
+    class Config:
+        extra = "ignore"
+
+
 @router.get("", response_model=list[NetworkSummary])
 async def list_networks(
     client: EeroClient = Depends(require_auth),
@@ -301,4 +310,28 @@ async def toggle_guest_network(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update guest network settings. Please try again.",
+        )
+
+
+@router.put("/{network_id}/name")
+async def rename_network(
+    network_id: str,
+    body: NetworkRenameRequest,
+    client: EeroClient = Depends(require_auth),
+) -> dict:
+    """Rename a network. Routed via /networks/{id}/settings (fixed in eero-api 4.1.2)."""
+    if not body.name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Network name cannot be empty",
+        )
+    try:
+        raw_result = await client.set_network_name(body.name.strip(), network_id)
+        success = check_success(raw_result)
+        return {"success": success, "network_id": network_id, "name": body.name.strip()}
+    except EeroException as e:
+        _LOGGER.error(f"Failed to rename network {network_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to rename network. Please try again.",
         )

--- a/backend/app/routes/profiles.py
+++ b/backend/app/routes/profiles.py
@@ -60,6 +60,24 @@ class ProfileAction(BaseModel):
     message: str | None = None
 
 
+class ProfileCreateRequest(BaseModel):
+    """Request body for creating a profile."""
+
+    name: str
+
+    class Config:
+        extra = "ignore"
+
+
+class ProfileRenameRequest(BaseModel):
+    """Request body for renaming a profile."""
+
+    name: str
+
+    class Config:
+        extra = "ignore"
+
+
 @router.get("", response_model=list[ProfileSummary])
 async def list_profiles(
     client: EeroClient = Depends(require_auth),
@@ -224,4 +242,133 @@ async def unpause_profile(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to resume profile. Please try again.",
+        )
+
+
+@router.post("", response_model=ProfileSummary, status_code=status.HTTP_201_CREATED)
+async def create_profile(
+    body: ProfileCreateRequest,
+    client: EeroClient = Depends(require_auth),
+    network_id: str = Depends(get_network_id),
+) -> ProfileSummary:
+    """Create a new profile on the network."""
+    if not body.name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Profile name cannot be empty",
+        )
+    try:
+        raw_response = await client.create_profile(body.name.strip(), network_id)
+        profile = normalize_profile(extract_data(raw_response))
+
+        profile_devices = [
+            ProfileDevice(
+                id=dev.get("id"),
+                url=dev.get("url"),
+                mac=dev.get("mac"),
+                nickname=dev.get("nickname"),
+                hostname=dev.get("hostname"),
+                display_name=dev.get("display_name"),
+                manufacturer=dev.get("manufacturer"),
+                connected=dev.get("connected", False),
+                wireless=dev.get("wireless", False),
+                paused=dev.get("paused", False),
+            )
+            for dev in profile.get("devices", [])
+        ]
+
+        return ProfileSummary(
+            id=profile.get("id"),
+            url=profile.get("url"),
+            name=profile.get("name") or "",
+            paused=profile.get("paused", False),
+            device_count=profile.get("device_count", 0),
+            device_ids=profile.get("device_ids", []),
+            devices=profile_devices,
+        )
+    except EeroException as e:
+        _LOGGER.error(f"Failed to create profile: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create profile. Please try again.",
+        )
+
+
+@router.patch("/{profile_id}", response_model=ProfileSummary)
+async def rename_profile(
+    profile_id: str,
+    body: ProfileRenameRequest,
+    client: EeroClient = Depends(require_auth),
+    network_id: str = Depends(get_network_id),
+) -> ProfileSummary:
+    """Rename an existing profile."""
+    if not body.name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Profile name cannot be empty",
+        )
+    try:
+        raw_response = await client.rename_profile(
+            profile_id, body.name.strip(), network_id
+        )
+        profile = normalize_profile(extract_data(raw_response))
+
+        profile_devices = [
+            ProfileDevice(
+                id=dev.get("id"),
+                url=dev.get("url"),
+                mac=dev.get("mac"),
+                nickname=dev.get("nickname"),
+                hostname=dev.get("hostname"),
+                display_name=dev.get("display_name"),
+                manufacturer=dev.get("manufacturer"),
+                connected=dev.get("connected", False),
+                wireless=dev.get("wireless", False),
+                paused=dev.get("paused", False),
+            )
+            for dev in profile.get("devices", [])
+        ]
+
+        return ProfileSummary(
+            id=profile.get("id"),
+            url=profile.get("url"),
+            name=profile.get("name") or "",
+            paused=profile.get("paused", False),
+            device_count=profile.get("device_count", 0),
+            device_ids=profile.get("device_ids", []),
+            devices=profile_devices,
+        )
+    except EeroException as e:
+        _LOGGER.error(f"Failed to rename profile {profile_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Profile not found: {profile_id}",
+        )
+
+
+@router.delete("/{profile_id}", response_model=ProfileAction)
+async def delete_profile(
+    profile_id: str,
+    client: EeroClient = Depends(require_auth),
+    network_id: str = Depends(get_network_id),
+) -> ProfileAction:
+    """Delete a profile from the network. Devices assigned to this profile will become unassigned."""
+    try:
+        raw_result = await client.delete_profile(profile_id, network_id)
+        success = check_success(raw_result)
+        return ProfileAction(
+            success=success,
+            profile_id=profile_id,
+            action="delete",
+            message=(
+                "Profile deleted. Assigned devices are now unassigned."
+                if success
+                else "Failed to delete profile."
+            ),
+        )
+    except EeroException as e:
+        _LOGGER.error(f"Failed to delete profile {profile_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete profile. Please try again.",
         )

--- a/backend/tests/test_networks.py
+++ b/backend/tests/test_networks.py
@@ -1,0 +1,125 @@
+"""Tests for network routes."""
+
+from unittest.mock import AsyncMock
+
+from eero.exceptions import EeroException
+
+
+def make_raw_response(data, code: int = 200):
+    """Helper to create a raw API response envelope."""
+    return {"meta": {"code": code}, "data": data}
+
+
+sample_network = {
+    "url": "/2.2/networks/net-1",
+    "name": "Home",
+    "status": "online",
+    "guest_network_enabled": False,
+}
+
+
+class TestListNetworks:
+    """Tests for GET /api/networks."""
+
+    async def test_list_networks_success(self, auth_client, authenticated_client):
+        """Returns list of networks."""
+        authenticated_client.get_networks = AsyncMock(
+            return_value=make_raw_response([sample_network])
+        )
+
+        response = await auth_client.get("/api/networks")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["name"] == "Home"
+
+
+class TestGetNetwork:
+    """Tests for GET /api/networks/{network_id}."""
+
+    async def test_get_network_success(self, auth_client, authenticated_client):
+        """Returns network details."""
+        authenticated_client.get_network = AsyncMock(
+            return_value=make_raw_response(sample_network)
+        )
+        authenticated_client.get_devices = AsyncMock(
+            return_value=make_raw_response([])
+        )
+        authenticated_client.get_eeros = AsyncMock(
+            return_value=make_raw_response([])
+        )
+
+        response = await auth_client.get("/api/networks/net-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Home"
+        assert data["status"] == "online"
+
+
+class TestRenameNetwork:
+    """Tests for PUT /api/networks/{network_id}/name."""
+
+    async def test_rename_network_success(self, auth_client, authenticated_client):
+        """Renames a network and returns success response."""
+        authenticated_client.set_network_name = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        response = await auth_client.put(
+            "/api/networks/net-1/name", json={"name": "Home"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["network_id"] == "net-1"
+        assert data["name"] == "Home"
+        authenticated_client.set_network_name.assert_called_once()
+
+    async def test_rename_network_empty_name(self, auth_client, authenticated_client):
+        """Empty name returns 400 without calling SDK."""
+        authenticated_client.set_network_name = AsyncMock()
+
+        response = await auth_client.put(
+            "/api/networks/net-1/name", json={"name": "   "}
+        )
+
+        assert response.status_code == 400
+        authenticated_client.set_network_name.assert_not_called()
+
+    async def test_rename_network_eero_exception(self, auth_client, authenticated_client):
+        """EeroException returns 500."""
+        authenticated_client.set_network_name = AsyncMock(
+            side_effect=EeroException("rename failed")
+        )
+
+        response = await auth_client.put(
+            "/api/networks/net-1/name", json={"name": "Home"}
+        )
+
+        assert response.status_code == 500
+
+
+class TestToggleGuestNetwork:
+    """Tests for PUT /api/networks/{network_id}/guest-network."""
+
+    async def test_toggle_guest_network_enable_with_name(
+        self, auth_client, authenticated_client
+    ):
+        """Enables guest network with a name and returns success."""
+        authenticated_client.set_guest_network = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        response = await auth_client.put(
+            "/api/networks/net-1/guest-network",
+            params={"enabled": "true", "name": "Guest"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["guest_network_enabled"] is True

--- a/backend/tests/test_networks.py
+++ b/backend/tests/test_networks.py
@@ -44,12 +44,8 @@ class TestGetNetwork:
         authenticated_client.get_network = AsyncMock(
             return_value=make_raw_response(sample_network)
         )
-        authenticated_client.get_devices = AsyncMock(
-            return_value=make_raw_response([])
-        )
-        authenticated_client.get_eeros = AsyncMock(
-            return_value=make_raw_response([])
-        )
+        authenticated_client.get_devices = AsyncMock(return_value=make_raw_response([]))
+        authenticated_client.get_eeros = AsyncMock(return_value=make_raw_response([]))
 
         response = await auth_client.get("/api/networks/net-1")
 
@@ -90,7 +86,9 @@ class TestRenameNetwork:
         assert response.status_code == 400
         authenticated_client.set_network_name.assert_not_called()
 
-    async def test_rename_network_eero_exception(self, auth_client, authenticated_client):
+    async def test_rename_network_eero_exception(
+        self, auth_client, authenticated_client
+    ):
         """EeroException returns 500."""
         authenticated_client.set_network_name = AsyncMock(
             side_effect=EeroException("rename failed")

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -35,7 +35,9 @@ class TestListProfiles:
         assert len(data) == 1
         assert data[0]["name"] == "Kids"
 
-    async def test_list_profiles_eero_exception(self, auth_client, authenticated_client):
+    async def test_list_profiles_eero_exception(
+        self, auth_client, authenticated_client
+    ):
         """EeroException returns 500."""
         authenticated_client.get_profiles = AsyncMock(
             side_effect=EeroException("API error")
@@ -97,7 +99,9 @@ class TestCreateProfile:
         assert response.status_code == 400
         authenticated_client.create_profile.assert_not_called()
 
-    async def test_create_profile_eero_exception(self, auth_client, authenticated_client):
+    async def test_create_profile_eero_exception(
+        self, auth_client, authenticated_client
+    ):
         """EeroException returns 500."""
         authenticated_client.create_profile = AsyncMock(
             side_effect=EeroException("create failed")
@@ -138,7 +142,9 @@ class TestRenameProfile:
         assert response.status_code == 400
         authenticated_client.rename_profile.assert_not_called()
 
-    async def test_rename_profile_eero_exception(self, auth_client, authenticated_client):
+    async def test_rename_profile_eero_exception(
+        self, auth_client, authenticated_client
+    ):
         """EeroException returns 404."""
         authenticated_client.rename_profile = AsyncMock(
             side_effect=EeroException("not found")
@@ -168,7 +174,9 @@ class TestDeleteProfile:
         assert data["action"] == "delete"
         authenticated_client.delete_profile.assert_called_once()
 
-    async def test_delete_profile_eero_exception(self, auth_client, authenticated_client):
+    async def test_delete_profile_eero_exception(
+        self, auth_client, authenticated_client
+    ):
         """EeroException returns 500."""
         authenticated_client.delete_profile = AsyncMock(
             side_effect=EeroException("delete failed")

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -1,0 +1,211 @@
+"""Tests for profile routes."""
+
+from unittest.mock import AsyncMock
+
+from eero.exceptions import EeroException
+
+
+def make_raw_response(data, code: int = 200):
+    """Helper to create a raw API response envelope."""
+    return {"meta": {"code": code}, "data": data}
+
+
+sample_profile = {
+    "url": "/2.2/networks/abc/profiles/profile-1",
+    "name": "Kids",
+    "paused": False,
+    "devices": [],
+}
+
+
+class TestListProfiles:
+    """Tests for GET /api/profiles."""
+
+    async def test_list_profiles_success(self, auth_client, authenticated_client):
+        """Returns list of profiles."""
+        authenticated_client.get_profiles = AsyncMock(
+            return_value=make_raw_response([sample_profile])
+        )
+
+        response = await auth_client.get("/api/profiles")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["name"] == "Kids"
+
+    async def test_list_profiles_eero_exception(self, auth_client, authenticated_client):
+        """EeroException returns 500."""
+        authenticated_client.get_profiles = AsyncMock(
+            side_effect=EeroException("API error")
+        )
+
+        response = await auth_client.get("/api/profiles")
+
+        assert response.status_code == 500
+
+
+class TestGetProfile:
+    """Tests for GET /api/profiles/{profile_id}."""
+
+    async def test_get_profile_success(self, auth_client, authenticated_client):
+        """Returns profile details."""
+        authenticated_client.get_profile = AsyncMock(
+            return_value=make_raw_response(sample_profile)
+        )
+
+        response = await auth_client.get("/api/profiles/profile-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Kids"
+
+    async def test_get_profile_eero_exception(self, auth_client, authenticated_client):
+        """EeroException returns 404."""
+        authenticated_client.get_profile = AsyncMock(
+            side_effect=EeroException("not found")
+        )
+
+        response = await auth_client.get("/api/profiles/profile-1")
+
+        assert response.status_code == 404
+
+
+class TestCreateProfile:
+    """Tests for POST /api/profiles."""
+
+    async def test_create_profile_success(self, auth_client, authenticated_client):
+        """Creates a profile and returns 201 with ProfileSummary."""
+        authenticated_client.create_profile = AsyncMock(
+            return_value=make_raw_response(sample_profile)
+        )
+
+        response = await auth_client.post("/api/profiles", json={"name": "Kids"})
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Kids"
+        authenticated_client.create_profile.assert_called_once()
+
+    async def test_create_profile_empty_name(self, auth_client, authenticated_client):
+        """Empty name returns 400 without calling SDK."""
+        authenticated_client.create_profile = AsyncMock()
+
+        response = await auth_client.post("/api/profiles", json={"name": "   "})
+
+        assert response.status_code == 400
+        authenticated_client.create_profile.assert_not_called()
+
+    async def test_create_profile_eero_exception(self, auth_client, authenticated_client):
+        """EeroException returns 500."""
+        authenticated_client.create_profile = AsyncMock(
+            side_effect=EeroException("create failed")
+        )
+
+        response = await auth_client.post("/api/profiles", json={"name": "Kids"})
+
+        assert response.status_code == 500
+
+
+class TestRenameProfile:
+    """Tests for PATCH /api/profiles/{profile_id}."""
+
+    async def test_rename_profile_success(self, auth_client, authenticated_client):
+        """Renames a profile and returns updated ProfileSummary."""
+        renamed_profile = {**sample_profile, "name": "Teens"}
+        authenticated_client.rename_profile = AsyncMock(
+            return_value=make_raw_response(renamed_profile)
+        )
+
+        response = await auth_client.patch(
+            "/api/profiles/profile-1", json={"name": "Teens"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Teens"
+        authenticated_client.rename_profile.assert_called_once()
+
+    async def test_rename_profile_empty_name(self, auth_client, authenticated_client):
+        """Empty name returns 400 without calling SDK."""
+        authenticated_client.rename_profile = AsyncMock()
+
+        response = await auth_client.patch(
+            "/api/profiles/profile-1", json={"name": "   "}
+        )
+
+        assert response.status_code == 400
+        authenticated_client.rename_profile.assert_not_called()
+
+    async def test_rename_profile_eero_exception(self, auth_client, authenticated_client):
+        """EeroException returns 404."""
+        authenticated_client.rename_profile = AsyncMock(
+            side_effect=EeroException("not found")
+        )
+
+        response = await auth_client.patch(
+            "/api/profiles/profile-1", json={"name": "Teens"}
+        )
+
+        assert response.status_code == 404
+
+
+class TestDeleteProfile:
+    """Tests for DELETE /api/profiles/{profile_id}."""
+
+    async def test_delete_profile_success(self, auth_client, authenticated_client):
+        """Deletes a profile and returns ProfileAction with success=True."""
+        authenticated_client.delete_profile = AsyncMock(
+            return_value=make_raw_response({}, code=200)
+        )
+
+        response = await auth_client.delete("/api/profiles/profile-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["action"] == "delete"
+        authenticated_client.delete_profile.assert_called_once()
+
+    async def test_delete_profile_eero_exception(self, auth_client, authenticated_client):
+        """EeroException returns 500."""
+        authenticated_client.delete_profile = AsyncMock(
+            side_effect=EeroException("delete failed")
+        )
+
+        response = await auth_client.delete("/api/profiles/profile-1")
+
+        assert response.status_code == 500
+
+
+class TestPauseProfile:
+    """Tests for POST /api/profiles/{profile_id}/pause."""
+
+    async def test_pause_profile_success(self, auth_client, authenticated_client):
+        """Pauses a profile and returns ProfileAction."""
+        authenticated_client.pause_profile = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        response = await auth_client.post("/api/profiles/profile-1/pause")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["action"] == "pause"
+
+
+class TestUnpauseProfile:
+    """Tests for POST /api/profiles/{profile_id}/unpause."""
+
+    async def test_unpause_profile_success(self, auth_client, authenticated_client):
+        """Unpauses a profile and returns ProfileAction."""
+        authenticated_client.pause_profile = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        response = await auth_client.post("/api/profiles/profile-1/unpause")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["action"] == "unpause"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -410,7 +410,7 @@ wheels = [
 
 [[package]]
 name = "eero-ui-backend"
-version = "4.10.0"
+version = "4.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "eero-api" },

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -33,7 +33,7 @@ export class ApiClientError extends Error {
  * HTTP client configuration
  */
 interface RequestConfig {
-	method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+	method?: 'GET' | 'PATCH' | 'POST' | 'PUT' | 'DELETE';
 	body?: unknown;
 	params?: Record<string, string | number | boolean>;
 	headers?: Record<string, string>;
@@ -220,6 +220,12 @@ export const api = {
 			fetchWithHandling<{ success: boolean }>(`/networks/${networkId}/guest-network`, {
 				method: 'PUT',
 				params: { enabled, ...(name && { name }) }
+			}),
+
+		setName: (networkId: string, name: string) =>
+			fetchWithHandling<import('./types').NetworkRenameResponse>(`/networks/${networkId}/name`, {
+				method: 'PUT',
+				body: { name }
 			})
 	},
 
@@ -325,6 +331,23 @@ export const api = {
 		unpause: (profileId: string) =>
 			fetchWithHandling<import('./types').ProfileAction>(`/profiles/${profileId}/unpause`, {
 				method: 'POST'
+			}),
+
+		create: (name: string) =>
+			fetchWithHandling<import('./types').ProfileSummary>('/profiles', {
+				method: 'POST',
+				body: { name }
+			}),
+
+		rename: (profileId: string, name: string) =>
+			fetchWithHandling<import('./types').ProfileSummary>(`/profiles/${profileId}`, {
+				method: 'PATCH',
+				body: { name }
+			}),
+
+		delete: (profileId: string) =>
+			fetchWithHandling<import('./types').ProfileAction>(`/profiles/${profileId}`, {
+				method: 'DELETE'
 			})
 	}
 };

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -154,6 +154,16 @@ export interface NetworkDetail extends NetworkSummary {
 	last_reboot: string | null;
 }
 
+export interface NetworkRenameRequest {
+	name: string;
+}
+
+export interface NetworkRenameResponse {
+	success: boolean;
+	network_id: string;
+	name: string;
+}
+
 export interface SpeedTestResult {
 	// Normalized format from backend
 	download_mbps?: number | null;
@@ -413,6 +423,14 @@ export interface ProfileAction {
 	profile_id: string;
 	action: string;
 	message: string | null;
+}
+
+export interface ProfileCreateRequest {
+	name: string;
+}
+
+export interface ProfileRenameRequest {
+	name: string;
 }
 
 // ============================================

--- a/frontend/src/routes/network/[id]/+page.svelte
+++ b/frontend/src/routes/network/[id]/+page.svelte
@@ -13,6 +13,9 @@
 	let error: string | null = null;
 	let speedTestLoading = false;
 	let guestToggleLoading = false;
+	let showRenameModal = false;
+	let renameValue = '';
+	let renaming = false;
 
 	$: networkId = $page.params.id;
 
@@ -77,6 +80,29 @@
 			uiStore.error(err instanceof Error ? err.message : 'Failed to toggle guest network');
 		} finally {
 			guestToggleLoading = false;
+		}
+	}
+
+	function openRenameNetworkModal() {
+		renameValue = network?.name ?? '';
+		showRenameModal = true;
+	}
+
+	async function handleRenameNetwork() {
+		const name = renameValue.trim();
+		if (!name || !networkId) return;
+		renaming = true;
+		try {
+			const result = await api.networks.setName(networkId, name);
+			if (network) {
+				network = { ...network, name: result.name };
+			}
+			uiStore.success(`Network renamed to "${result.name}"`);
+			showRenameModal = false;
+		} catch (err) {
+			uiStore.error(err instanceof Error ? err.message : 'Failed to rename network');
+		} finally {
+			renaming = false;
 		}
 	}
 
@@ -294,6 +320,9 @@
 			<div class="header-actions">
 				<button class="btn btn-secondary" on:click={() => fetchNetwork(true)} disabled={loading}>
 					↻ Refresh
+				</button>
+				<button class="btn btn-secondary" on:click={openRenameNetworkModal} disabled={loading}>
+					✎ Rename
 				</button>
 			</div>
 		</header>
@@ -826,6 +855,48 @@
 			<section class="network-charts">
 				<SpeedtestChart {networkId} />
 			</section>
+		{/if}
+
+		{#if showRenameModal}
+			<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+			<div class="modal-backdrop" on:click={() => (showRenameModal = false)}>
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="modal-card card" on:click|stopPropagation>
+					<h2>Rename Network</h2>
+					<form on:submit|preventDefault={handleRenameNetwork}>
+						<label class="modal-label" for="rename-network-input">New name</label>
+						<!-- svelte-ignore a11y_autofocus -->
+						<input
+							id="rename-network-input"
+							class="modal-input"
+							type="text"
+							bind:value={renameValue}
+							disabled={renaming}
+							autofocus
+						/>
+						<div class="modal-actions">
+							<button
+								type="button"
+								class="btn btn-secondary"
+								on:click={() => (showRenameModal = false)}
+								disabled={renaming}
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								class="btn btn-primary"
+								disabled={renaming || !renameValue.trim()}
+							>
+								{#if renaming}
+									<span class="loading-spinner"></span>
+								{/if}
+								Save
+							</button>
+						</div>
+					</form>
+				</div>
+			</div>
 		{/if}
 	{/if}
 </div>
@@ -1480,5 +1551,58 @@
 			flex-direction: column;
 			align-items: stretch;
 		}
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background-color: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.modal-card {
+		width: 100%;
+		max-width: 400px;
+		padding: var(--space-6);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.modal-card h2 {
+		margin: 0;
+		font-size: 1.125rem;
+	}
+
+	.modal-label {
+		display: block;
+		font-size: 0.875rem;
+		color: var(--color-text-secondary);
+		margin-bottom: var(--space-2);
+	}
+
+	.modal-input {
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		background-color: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		color: var(--color-text-primary);
+		font-size: 0.9375rem;
+		box-sizing: border-box;
+	}
+
+	.modal-input:focus {
+		outline: none;
+		border-color: var(--color-accent);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-3);
 	}
 </style>

--- a/frontend/src/routes/profiles/+page.svelte
+++ b/frontend/src/routes/profiles/+page.svelte
@@ -16,6 +16,9 @@
 	let error: string | null = null;
 	let viewMode: 'blocks' | 'list' = 'blocks';
 	let lastNetworkId: string | null = null;
+	let showCreateModal = false;
+	let newProfileName = '';
+	let creating = false;
 
 	onMount(async () => {
 		lastNetworkId = $selectedNetworkId;
@@ -54,6 +57,23 @@
 
 	function getProfileKey(profile: ProfileSummary, index: number): string {
 		return profile.id || `profile-${index}`;
+	}
+
+	async function handleCreateProfile() {
+		const name = newProfileName.trim();
+		if (!name) return;
+		creating = true;
+		try {
+			await api.profiles.create(name);
+			uiStore.success(`Profile "${name}" created`);
+			showCreateModal = false;
+			newProfileName = '';
+			await fetchProfiles(true);
+		} catch (err) {
+			uiStore.error(err instanceof Error ? err.message : 'Failed to create profile');
+		} finally {
+			creating = false;
+		}
 	}
 </script>
 
@@ -94,6 +114,9 @@
 					↻
 				{/if}
 				Refresh
+			</button>
+			<button class="btn btn-primary" on:click={() => (showCreateModal = true)}>
+				+ New profile
 			</button>
 		</div>
 	</header>
@@ -174,6 +197,49 @@
 					{/each}
 				</tbody>
 			</table>
+		</div>
+	{/if}
+
+	{#if showCreateModal}
+		<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+		<div class="modal-backdrop" on:click={() => (showCreateModal = false)}>
+			<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+			<div class="modal-card card" on:click|stopPropagation>
+				<h2>New Profile</h2>
+				<form on:submit|preventDefault={handleCreateProfile}>
+					<label class="modal-label" for="new-profile-name">Profile name</label>
+					<!-- svelte-ignore a11y_autofocus -->
+					<input
+						id="new-profile-name"
+						class="modal-input"
+						type="text"
+						bind:value={newProfileName}
+						placeholder="e.g. Kids"
+						disabled={creating}
+						autofocus
+					/>
+					<div class="modal-actions">
+						<button
+							type="button"
+							class="btn btn-secondary"
+							on:click={() => (showCreateModal = false)}
+							disabled={creating}
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							class="btn btn-primary"
+							disabled={creating || !newProfileName.trim()}
+						>
+							{#if creating}
+								<span class="loading-spinner"></span>
+							{/if}
+							Create
+						</button>
+					</div>
+				</form>
+			</div>
 		</div>
 	{/if}
 </div>
@@ -397,5 +463,58 @@
 	.badge-warning {
 		background-color: var(--color-warning);
 		color: var(--color-bg-primary);
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background-color: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.modal-card {
+		width: 100%;
+		max-width: 400px;
+		padding: var(--space-6);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.modal-card h2 {
+		margin: 0;
+		font-size: 1.125rem;
+	}
+
+	.modal-label {
+		display: block;
+		font-size: 0.875rem;
+		color: var(--color-text-secondary);
+		margin-bottom: var(--space-2);
+	}
+
+	.modal-input {
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		background-color: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		color: var(--color-text-primary);
+		font-size: 0.9375rem;
+		box-sizing: border-box;
+	}
+
+	.modal-input:focus {
+		outline: none;
+		border-color: var(--color-accent);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-3);
 	}
 </style>

--- a/frontend/src/routes/profiles/[id]/+page.svelte
+++ b/frontend/src/routes/profiles/[id]/+page.svelte
@@ -17,6 +17,9 @@
 	let error: string | null = null;
 	let actionLoading = false;
 	let viewMode: 'blocks' | 'list' = 'blocks';
+	let showRenameModal = false;
+	let renameValue = '';
+	let renaming = false;
 
 	$: profileId = $page.params.id;
 	$: devices = profile?.devices || [];
@@ -127,6 +130,41 @@
 	function getDeviceKey(device: ProfileDevice, index: number): string {
 		return device.id || device.mac || `device-${index}`;
 	}
+
+	function openRenameModal() {
+		renameValue = profile?.name ?? '';
+		showRenameModal = true;
+	}
+
+	async function handleRenameProfile() {
+		const name = renameValue.trim();
+		if (!name || !profileId) return;
+		renaming = true;
+		try {
+			profile = await api.profiles.rename(profileId, name);
+			uiStore.success(`Profile renamed to "${name}"`);
+			showRenameModal = false;
+		} catch (err) {
+			uiStore.error(err instanceof Error ? err.message : 'Failed to rename profile');
+		} finally {
+			renaming = false;
+		}
+	}
+
+	function handleDeleteProfile() {
+		if (!profileId) return;
+		uiStore.confirm({
+			title: 'Delete Profile',
+			message: 'Are you sure? Devices assigned to this profile will become unassigned.',
+			confirmText: 'Delete',
+			danger: true,
+			onConfirm: async () => {
+				await api.profiles.delete(profileId);
+				uiStore.success('Profile deleted');
+				goto('/profiles');
+			}
+		});
+	}
 </script>
 
 <svelte:head>
@@ -173,6 +211,12 @@
 					disabled={actionLoading}
 				>
 					↻ Refresh
+				</button>
+				<button class="btn btn-secondary" on:click={openRenameModal} disabled={actionLoading}>
+					✎ Rename
+				</button>
+				<button class="btn btn-danger" on:click={handleDeleteProfile} disabled={actionLoading}>
+					Delete
 				</button>
 				<button
 					class="btn {profile.paused ? 'btn-primary' : 'btn-warning'}"
@@ -411,6 +455,48 @@
 				</div>
 			{/if}
 		</section>
+
+		{#if showRenameModal}
+			<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+			<div class="modal-backdrop" on:click={() => (showRenameModal = false)}>
+				<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+				<div class="modal-card card" on:click|stopPropagation>
+					<h2>Rename Profile</h2>
+					<form on:submit|preventDefault={handleRenameProfile}>
+						<label class="modal-label" for="rename-profile-input">New name</label>
+						<!-- svelte-ignore a11y_autofocus -->
+						<input
+							id="rename-profile-input"
+							class="modal-input"
+							type="text"
+							bind:value={renameValue}
+							disabled={renaming}
+							autofocus
+						/>
+						<div class="modal-actions">
+							<button
+								type="button"
+								class="btn btn-secondary"
+								on:click={() => (showRenameModal = false)}
+								disabled={renaming}
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								class="btn btn-primary"
+								disabled={renaming || !renameValue.trim()}
+							>
+								{#if renaming}
+									<span class="loading-spinner"></span>
+								{/if}
+								Save
+							</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		{/if}
 	{/if}
 </div>
 
@@ -820,5 +906,67 @@
 		.header-meta {
 			padding-left: 0;
 		}
+	}
+
+	.btn-danger {
+		background-color: var(--color-danger);
+		color: white;
+	}
+
+	.btn-danger:hover:not(:disabled) {
+		opacity: 0.85;
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background-color: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.modal-card {
+		width: 100%;
+		max-width: 400px;
+		padding: var(--space-6);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.modal-card h2 {
+		margin: 0;
+		font-size: 1.125rem;
+	}
+
+	.modal-label {
+		display: block;
+		font-size: 0.875rem;
+		color: var(--color-text-secondary);
+		margin-bottom: var(--space-2);
+	}
+
+	.modal-input {
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		background-color: var(--color-bg-primary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		color: var(--color-text-primary);
+		font-size: 0.9375rem;
+		box-sizing: border-box;
+	}
+
+	.modal-input:focus {
+		outline: none;
+		border-color: var(--color-accent);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-3);
 	}
 </style>


### PR DESCRIPTION
## Summary

Follow-up work to PR #172 (eero-api 4.0.7 → 4.1.2 bump). PR #172 was a clean dep bump, but the version window unlocked three new SDK methods and a routing fix that this PR surfaces end-to-end.

### What's new

**Backend (FastAPI):**
- `POST   /api/profiles` — create a profile
- `PATCH  /api/profiles/{profile_id}` — rename a profile
- `DELETE /api/profiles/{profile_id}` — delete a profile (devices become unassigned)
- `PUT    /api/networks/{network_id}/name` — rename a network (relies on the `set_network_name` routing fix from eero-api 4.1.2)

Empty-name requests return `400`. SDK failures map to `500` (create/delete/rename-network) or `404` (rename-profile, mirroring the existing `get_profile` convention).

**Frontend (SvelteKit + TypeScript):**
- `ProfileCreateRequest` / `ProfileRenameRequest` / `NetworkRenameRequest` / `NetworkRenameResponse` types.
- `api.profiles.create/rename/delete` and `api.networks.setName` client methods.
- `PATCH` added to the `RequestConfig.method` union.
- "+ New profile" button + inline modal on the profiles list page.
- "Rename" + "Delete" actions on the profile detail page (delete uses the existing `uiStore.confirm` pattern; rename uses an inline modal since `uiStore.confirm` doesn't support text input).
- "Rename" button + inline modal on the network detail page.

**Style:** all `a11y_autofocus` warnings on the new modal inputs are gated with the same `<!-- svelte-ignore -->` pattern used elsewhere in the repo (`ConfirmDialog.svelte`).

## Verification

- Backend: `86 passed` (`pytest tests/`), `ruff` clean.
- Frontend: `npm run lint` 0 errors, `npm run check` 0 errors. Test suite: `7 passed | 5 skipped` (identical to pre-existing baseline).
- All four new backend endpoints have dedicated unit tests with mocked `EeroClient`.

## Notes

The third commit (`chore(deps): regenerate uv.lock to match pyproject 4.11.0`) corrects a stale lockfile from the `4.11.0` release commit on `master`, which bumped `backend/pyproject.toml` to `4.11.0` but left `backend/uv.lock` at `4.10.0`. Running `uv` re-synced it.

## Specialist agent ownership

| Layer | Owner (VoltAgent catalog) |
|---|---|
| Backend FastAPI routes + pytest | `voltagent-core-dev:backend-developer` |
| SvelteKit UI + TS client/types | `voltagent-core-dev:frontend-developer` (Svelte fallback — no dedicated Svelte agent in catalog) |
| Coordination, contract-locking, final review | `agent-organizer` (claude orchestrator) |

## Test plan

- [x] Backend tests pass locally
- [x] Backend lint clean
- [x] Frontend lint + svelte-check clean
- [x] Frontend tests pass (no new failures vs baseline)
- [ ] CI pipeline green
- [ ] Manual smoke: create / rename / delete profile from UI
- [ ] Manual smoke: rename network from UI (validates the eero-api 4.1.2 `set_network_name` routing fix end-to-end)
- [ ] Manual smoke: toggle guest network (regression check after the 4.1.2 `/settings` routing fix — QA-001 from the evaluation backlog)