### PR TITLE
fix: coerce uptime and numeric fields from dict shapes

### DIFF
--- a/backend/app/_coercion.py
+++ b/backend/app/_coercion.py
@@ -1,0 +1,89 @@
+"""Numeric coercion helpers for raw Eero Cloud API responses.
+
+The Eero Cloud API occasionally changes numeric fields to structured dict
+shapes (e.g. uptime: 1000 becomes uptime: {"seconds": 1000, "human": "16m"}).
+This module provides safe coercion so callers always receive a float/int or None.
+"""
+
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Tracks (field_name, frozenset_of_keys) pairs already logged so we only
+# emit each unknown-dict shape once per process lifetime.
+_UNKNOWN_DICT_LOGGED: set[tuple[str, frozenset[str]]] = set()
+
+# Ordered candidate keys to probe when coercing a dict to a number.
+_CANDIDATE_KEYS = ("seconds", "value", "current", "total", "count")
+
+
+def coerce_numeric(
+    value: Any,
+    field_name: str = "<unknown>",
+) -> float | None:
+    """Coerce an API field value to float, returning None when impossible.
+
+    Handles the following input shapes:
+
+    - ``int`` / ``float``  → cast to float and return.
+    - ``str``              → ``float(value)`` on success; None on ValueError.
+    - ``dict``             → probe candidate keys in order
+                             (``seconds``, ``value``, ``current``, ``total``,
+                             ``count``), recursively coerce the first hit.
+                             Unknown shapes are logged once at DEBUG and return
+                             None.
+    - ``None`` / other     → return None.
+
+    Args:
+        value:      The raw value from the API response.
+        field_name: Name of the field being coerced (used in log messages).
+
+    Returns:
+        A ``float`` on success, or ``None`` when the value cannot be coerced.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        # bool is a subclass of int; treat it as non-numeric.
+        return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            _LOGGER.debug(
+                "coerce_numeric: cannot parse string %r for field %r",
+                value,
+                field_name,
+            )
+            return None
+
+    if isinstance(value, dict):
+        for key in _CANDIDATE_KEYS:
+            if key in value:
+                return coerce_numeric(value[key], field_name=field_name)
+
+        # No known key found — log once per unique (field_name, key_set) pair.
+        key_frozenset = frozenset(value.keys())
+        dedup_key = (field_name, key_frozenset)
+        if dedup_key not in _UNKNOWN_DICT_LOGGED:
+            _UNKNOWN_DICT_LOGGED.add(dedup_key)
+            _LOGGER.debug(
+                "coerce_numeric: unknown dict shape for field %r with keys %s; "
+                "returning None (logged once)",
+                field_name,
+                sorted(value.keys()),
+            )
+        return None
+
+    _LOGGER.debug(
+        "coerce_numeric: unsupported type %s for field %r; returning None",
+        type(value).__name__,
+        field_name,
+    )
+    return None

--- a/backend/app/routes/eeros.py
+++ b/backend/app/routes/eeros.py
@@ -8,6 +8,7 @@ from eero.exceptions import EeroException
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
+from .._coercion import coerce_numeric
 from ..deps import get_network_id, require_auth
 from ..transformers import check_success, extract_data, extract_list, normalize_eero
 
@@ -289,6 +290,16 @@ async def get_eero(
                 for addr in ipv6_addresses
             ]
 
+        # Coerce numeric performance fields — the Eero Cloud API may return
+        # these as dicts (e.g. {"seconds": N}) instead of plain numbers.
+        # coerce_numeric() always yields float | None so callers are safe.
+        _raw_uptime = coerce_numeric(eero.get("uptime"), field_name="uptime")
+        uptime_seconds: int | None = (
+            int(_raw_uptime)
+            if _raw_uptime is not None
+            else calculate_uptime_seconds(eero.get("last_reboot"))
+        )
+
         return EeroDetail(
             id=eero.get("id") or eero.get("serial") or eero_id,
             url=eero.get("url") or "",
@@ -315,11 +326,14 @@ async def get_eero(
             os_version=eero.get("os_version"),
             led_on=eero.get("led_on"),
             led_brightness=eero.get("led_brightness"),
-            uptime=eero.get("uptime")
-            or calculate_uptime_seconds(eero.get("last_reboot")),
-            cpu_usage=eero.get("cpu_usage"),
-            memory_usage=eero.get("memory_usage"),
-            temperature=eero.get("temperature"),
+            uptime=uptime_seconds,
+            cpu_usage=coerce_numeric(eero.get("cpu_usage"), field_name="cpu_usage"),
+            memory_usage=coerce_numeric(
+                eero.get("memory_usage"), field_name="memory_usage"
+            ),
+            temperature=coerce_numeric(
+                eero.get("temperature"), field_name="temperature"
+            ),
             heartbeat_ok=eero.get("heartbeat_ok"),
             update_available=eero.get("update_available"),
             provides_wifi=eero.get("provides_wifi"),

--- a/backend/app/transformers.py
+++ b/backend/app/transformers.py
@@ -8,6 +8,8 @@ This module provides extraction and normalization functions.
 
 from typing import Any
 
+from ._coercion import coerce_numeric
+
 
 def extract_data(raw_response: Any) -> dict[str, Any]:
     """Extract data from raw API response envelope.
@@ -438,10 +440,14 @@ def normalize_eero(raw: dict[str, Any]) -> dict[str, Any]:
         "os_version": raw.get("os_version") or raw.get("os"),
         "led_on": raw.get("led_on"),
         "led_brightness": raw.get("led_brightness"),
-        "uptime": raw.get("uptime"),
-        "cpu_usage": raw.get("cpu_usage"),
-        "memory_usage": raw.get("memory_usage"),
-        "temperature": raw.get("temperature"),
+        "uptime": coerce_numeric(raw.get("uptime"), field_name="uptime"),
+        "cpu_usage": coerce_numeric(raw.get("cpu_usage"), field_name="cpu_usage"),
+        "memory_usage": coerce_numeric(
+            raw.get("memory_usage"), field_name="memory_usage"
+        ),
+        "temperature": coerce_numeric(
+            raw.get("temperature"), field_name="temperature"
+        ),
         "heartbeat_ok": raw.get("heartbeat_ok"),
         "update_available": raw.get("update_available"),
         "provides_wifi": raw.get("provides_wifi"),

--- a/backend/app/transformers.py
+++ b/backend/app/transformers.py
@@ -445,9 +445,7 @@ def normalize_eero(raw: dict[str, Any]) -> dict[str, Any]:
         "memory_usage": coerce_numeric(
             raw.get("memory_usage"), field_name="memory_usage"
         ),
-        "temperature": coerce_numeric(
-            raw.get("temperature"), field_name="temperature"
-        ),
+        "temperature": coerce_numeric(raw.get("temperature"), field_name="temperature"),
         "heartbeat_ok": raw.get("heartbeat_ok"),
         "update_available": raw.get("update_available"),
         "provides_wifi": raw.get("provides_wifi"),

--- a/backend/tests/test_coercion.py
+++ b/backend/tests/test_coercion.py
@@ -1,0 +1,274 @@
+"""Unit tests for the _coercion module.
+
+Tests cover:
+- coerce_numeric with int, float, str, dict, None, and other types
+- Dict key probe order (seconds, value, current, total, count)
+- Unknown dict shapes return None and log once (dedup)
+- Recursive dict coercion
+- Boolean inputs treated as non-numeric
+"""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app._coercion import _UNKNOWN_DICT_LOGGED, coerce_numeric
+
+
+# ========================== coerce_numeric Tests ==========================
+
+
+class TestCoerceNumericScalars:
+    """Tests for scalar (int, float, str, None) inputs."""
+
+    def setup_method(self):
+        """Clear dedup set before each test."""
+        _UNKNOWN_DICT_LOGGED.clear()
+
+    def test_int_returns_float(self):
+        """Int input is returned as float."""
+        result = coerce_numeric(1000)
+        assert result == 1000.0
+        assert isinstance(result, float)
+
+    def test_float_returns_float(self):
+        """Float input is returned as float."""
+        result = coerce_numeric(3.14)
+        assert result == 3.14
+
+    def test_zero_int(self):
+        """Zero int returns 0.0, not None."""
+        assert coerce_numeric(0) == 0.0
+
+    def test_zero_float(self):
+        """Zero float returns 0.0, not None."""
+        assert coerce_numeric(0.0) == 0.0
+
+    def test_none_returns_none(self):
+        """None input returns None."""
+        assert coerce_numeric(None) is None
+
+    def test_bool_true_returns_none(self):
+        """True is a bool subclass of int but should not be coerced."""
+        assert coerce_numeric(True) is None
+
+    def test_bool_false_returns_none(self):
+        """False is a bool subclass of int but should not be coerced."""
+        assert coerce_numeric(False) is None
+
+    def test_numeric_string(self):
+        """Numeric string is parsed to float."""
+        assert coerce_numeric("42") == 42.0
+        assert coerce_numeric("3.14") == 3.14
+
+    def test_non_numeric_string_returns_none(self):
+        """Non-numeric string returns None."""
+        assert coerce_numeric("not-a-number") is None
+        assert coerce_numeric("") is None
+
+    def test_list_returns_none(self):
+        """List input returns None."""
+        assert coerce_numeric([1, 2, 3]) is None
+
+    def test_object_returns_none(self):
+        """Arbitrary object returns None."""
+        assert coerce_numeric(object()) is None
+
+
+class TestCoerceNumericDict:
+    """Tests for dict inputs probing candidate keys."""
+
+    def setup_method(self):
+        """Clear dedup set before each test."""
+        _UNKNOWN_DICT_LOGGED.clear()
+
+    def test_seconds_key(self):
+        """Dict with 'seconds' key returns that value."""
+        assert coerce_numeric({"seconds": 1000, "human": "16m"}) == 1000.0
+
+    def test_value_key(self):
+        """Dict with 'value' key returns that value."""
+        assert coerce_numeric({"value": 42}) == 42.0
+
+    def test_current_key(self):
+        """Dict with 'current' key returns that value."""
+        assert coerce_numeric({"current": 99}) == 99.0
+
+    def test_total_key(self):
+        """Dict with 'total' key returns that value."""
+        assert coerce_numeric({"total": 500}) == 500.0
+
+    def test_count_key(self):
+        """Dict with 'count' key returns that value."""
+        assert coerce_numeric({"count": 7}) == 7.0
+
+    def test_seconds_takes_priority_over_value(self):
+        """'seconds' is probed before 'value'."""
+        result = coerce_numeric({"seconds": 100, "value": 999})
+        assert result == 100.0
+
+    def test_recursive_dict(self):
+        """Nested dict value is recursively coerced."""
+        result = coerce_numeric({"seconds": {"value": 55}})
+        assert result == 55.0
+
+    def test_unknown_dict_returns_none(self):
+        """Dict with no candidate keys returns None."""
+        result = coerce_numeric({"foo": 1, "bar": 2}, field_name="uptime")
+        assert result is None
+
+    def test_unknown_dict_logs_once(self, caplog):
+        """Unknown dict shape is logged at DEBUG exactly once per unique shape."""
+        with caplog.at_level(logging.DEBUG, logger="app._coercion"):
+            coerce_numeric({"foo": 1}, field_name="uptime")
+            coerce_numeric({"foo": 1}, field_name="uptime")  # duplicate — no extra log
+
+        debug_records = [
+            r for r in caplog.records if "unknown dict shape" in r.message
+        ]
+        assert len(debug_records) == 1
+
+    def test_different_unknown_shapes_each_logged_once(self, caplog):
+        """Different unknown shapes each get their own log entry."""
+        with caplog.at_level(logging.DEBUG, logger="app._coercion"):
+            coerce_numeric({"foo": 1}, field_name="uptime")
+            coerce_numeric({"bar": 2}, field_name="uptime")
+
+        debug_records = [
+            r for r in caplog.records if "unknown dict shape" in r.message
+        ]
+        assert len(debug_records) == 2
+
+    def test_empty_dict_returns_none(self):
+        """Empty dict has no candidate keys, returns None."""
+        assert coerce_numeric({}) is None
+
+
+# ========================== Route Regression Tests ==========================
+
+
+class TestEerosRouteUptimeCoercion:
+    """Regression tests for the uptime-dict-500 bug (upstream #61).
+
+    Simulates the Eero Cloud API returning uptime as a dict and asserts
+    the /api/networks/{id}/eeros/{eero_id} endpoint returns HTTP 200
+    with the correct integer uptime value.
+    """
+
+    @pytest.fixture
+    def sample_eero_raw(self):
+        """Minimal raw eero payload with uptime as a dict."""
+        return {
+            "url": "/2.2/eeros/eero-abc",
+            "serial": "SN-001",
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "model": "eero Pro 6",
+            "status": "online",
+            "location": "Living Room",
+            "is_gateway": True,
+            "is_primary": True,
+            "connected_clients_count": 5,
+            "firmware_version": "7.0.0",
+            "uptime": {"seconds": 1000, "human": "16m"},
+            "cpu_usage": 12.5,
+            "memory_usage": 45.0,
+            "temperature": 55.0,
+        }
+
+    async def test_uptime_dict_returns_200(
+        self, auth_client, authenticated_client, sample_eero_raw
+    ):
+        """Endpoint returns 200 when uptime is a dict with 'seconds' key."""
+        authenticated_client.get_eero = AsyncMock(
+            return_value={
+                "meta": {"code": 200},
+                "data": sample_eero_raw,
+            }
+        )
+
+        response = await auth_client.get("/api/eeros/eero-abc")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uptime"] == 1000
+
+    async def test_uptime_dict_value_key_returns_200(
+        self, auth_client, authenticated_client, sample_eero_raw
+    ):
+        """Endpoint handles dict with 'value' key correctly."""
+        raw = dict(sample_eero_raw)
+        raw["uptime"] = {"value": 2500}
+        authenticated_client.get_eero = AsyncMock(
+            return_value={"meta": {"code": 200}, "data": raw}
+        )
+
+        response = await auth_client.get("/api/eeros/eero-abc")
+
+        assert response.status_code == 200
+        assert response.json()["uptime"] == 2500
+
+    async def test_uptime_plain_int_still_works(
+        self, auth_client, authenticated_client, sample_eero_raw
+    ):
+        """Normal numeric uptime continues to work after the fix."""
+        raw = dict(sample_eero_raw)
+        raw["uptime"] = 86400
+        authenticated_client.get_eero = AsyncMock(
+            return_value={"meta": {"code": 200}, "data": raw}
+        )
+
+        response = await auth_client.get("/api/eeros/eero-abc")
+
+        assert response.status_code == 200
+        assert response.json()["uptime"] == 86400
+
+    async def test_uptime_none_falls_back_to_last_reboot(
+        self, auth_client, authenticated_client, sample_eero_raw
+    ):
+        """When uptime is absent, last_reboot fallback is used."""
+        raw = dict(sample_eero_raw)
+        raw["uptime"] = None
+        raw["last_reboot"] = "2026-05-20T12:00:00Z"
+        authenticated_client.get_eero = AsyncMock(
+            return_value={"meta": {"code": 200}, "data": raw}
+        )
+
+        response = await auth_client.get("/api/eeros/eero-abc")
+
+        assert response.status_code == 200
+        # Uptime calculated from last_reboot should be a positive integer
+        assert response.json()["uptime"] is not None
+        assert response.json()["uptime"] > 0
+
+    async def test_uptime_unknown_dict_returns_200_with_none(
+        self, auth_client, authenticated_client, sample_eero_raw
+    ):
+        """Unknown dict shape degrades to None (or last_reboot fallback)."""
+        raw = dict(sample_eero_raw)
+        raw["uptime"] = {"mystery_key": 999}
+        raw["last_reboot"] = None
+        authenticated_client.get_eero = AsyncMock(
+            return_value={"meta": {"code": 200}, "data": raw}
+        )
+
+        response = await auth_client.get("/api/eeros/eero-abc")
+
+        # Must not 500
+        assert response.status_code == 200
+        assert response.json()["uptime"] is None
+
+    async def test_cpu_usage_dict_coerced(
+        self, auth_client, authenticated_client, sample_eero_raw
+    ):
+        """cpu_usage dict is coerced to float correctly."""
+        raw = dict(sample_eero_raw)
+        raw["cpu_usage"] = {"value": 23.7}
+        authenticated_client.get_eero = AsyncMock(
+            return_value={"meta": {"code": 200}, "data": raw}
+        )
+
+        response = await auth_client.get("/api/eeros/eero-abc")
+
+        assert response.status_code == 200
+        assert response.json()["cpu_usage"] == pytest.approx(23.7)

--- a/backend/tests/test_coercion.py
+++ b/backend/tests/test_coercion.py
@@ -9,12 +9,11 @@ Tests cover:
 """
 
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from app._coercion import _UNKNOWN_DICT_LOGGED, coerce_numeric
-
 
 # ========================== coerce_numeric Tests ==========================
 
@@ -124,9 +123,7 @@ class TestCoerceNumericDict:
             coerce_numeric({"foo": 1}, field_name="uptime")
             coerce_numeric({"foo": 1}, field_name="uptime")  # duplicate — no extra log
 
-        debug_records = [
-            r for r in caplog.records if "unknown dict shape" in r.message
-        ]
+        debug_records = [r for r in caplog.records if "unknown dict shape" in r.message]
         assert len(debug_records) == 1
 
     def test_different_unknown_shapes_each_logged_once(self, caplog):
@@ -135,9 +132,7 @@ class TestCoerceNumericDict:
             coerce_numeric({"foo": 1}, field_name="uptime")
             coerce_numeric({"bar": 2}, field_name="uptime")
 
-        debug_records = [
-            r for r in caplog.records if "unknown dict shape" in r.message
-        ]
+        debug_records = [r for r in caplog.records if "unknown dict shape" in r.message]
         assert len(debug_records) == 2
 
     def test_empty_dict_returns_none(self):


### PR DESCRIPTION
## Root Cause

The Eero Cloud API changed the `uptime` field on `/2.2/networks/{id}/eeros` from a plain integer (seconds) to a structured dict (e.g. `{"seconds": 1000, "human": "16m"}`). A dict is truthy in Python, so the existing guard:

```python
uptime=eero.get("uptime") or calculate_uptime_seconds(eero.get("last_reboot")),
```

short-circuited on the dict value and attempted to assign it to Pydantic's `int | None` field — causing a `ValidationError` and a **500 on every `GET /api/eeros/{id}` request**.

Discovery context: [fulviofreitas/eero-prometheus-exporter#61](https://github.com/fulviofreitas/eero-prometheus-exporter/issues/61)

## Approach

**New helper: `backend/app/_coercion.py` — `coerce_numeric(value, field_name)`**
- `int | float` → cast to `float`
- `str` → `float()`, returns `None` on `ValueError`
- `dict` → probes keys in order: `seconds`, `value`, `current`, `total`, `count`; recursively coerces the first hit; logs unknown shapes once at DEBUG (deduped by `(field_name, frozenset(keys))`)
- `None` / other → `None`

**Fixed sites:**
- `routes/eeros.py:318-319` — `uptime`, `cpu_usage`, `memory_usage`, `temperature` all routed through `coerce_numeric()`. Uptime uses a pre-computed variable so the `int()` cast and `last_reboot` fallback are clear.
- `transformers.py:441` — same four fields coerced in `normalize_eero()` so any downstream consumer that reads the transformer output also sees numbers.

## Test Plan

- [x] `TestCoerceNumericScalars` — int, float, zero, None, bool, numeric string, non-numeric string, list, object
- [x] `TestCoerceNumericDict` — each of the 5 candidate keys, key priority, recursive dicts, unknown shape returns None, unknown shape logged exactly once, different shapes each logged once, empty dict
- [x] `TestEerosRouteUptimeCoercion` — regression: `uptime={"seconds": 1000, "human": "16m"}` → HTTP 200, `uptime == 1000`; `value` key variant; plain int still works; None falls back to `last_reboot`; unknown dict degrades to None (no 500); `cpu_usage` dict coerced
- [x] Full backend suite: **114 passed, 0 failed**

## Frontend

No frontend changes were needed. `frontend/src/lib/api/types.ts:344` declares `uptime: number | null` and `frontend/src/routes/eeros/[id]/+page.svelte:384` calls `formatUptime(eero.uptime)`. All traffic reaches the frontend exclusively through the FastAPI backend — with dict coercion now done server-side, the type contract (`number | null`) is preserved end-to-end.