### PR TITLE
fix: handle variable Eero API response shapes (#193, #194)

### DIFF
--- a/backend/app/_coercion.py
+++ b/backend/app/_coercion.py
@@ -1,8 +1,11 @@
-"""Numeric coercion helpers for raw Eero Cloud API responses.
+"""Type coercion helpers for raw Eero Cloud API responses.
 
-The Eero Cloud API occasionally changes numeric fields to structured dict
-shapes (e.g. uptime: 1000 becomes uptime: {"seconds": 1000, "human": "16m"}).
-This module provides safe coercion so callers always receive a float/int or None.
+The Eero Cloud API occasionally changes field shapes between releases — a
+numeric field may become a structured dict (e.g. uptime: 1000 becomes
+uptime: {"seconds": 1000, "human": "16m"}), and a boolean field may arrive
+as a string or a nested object. This module provides safe coercion so
+callers always receive a predictable type (or None) instead of crashing
+downstream model validation.
 """
 
 import logging
@@ -83,6 +86,98 @@ def coerce_numeric(
 
     _LOGGER.debug(
         "coerce_numeric: unsupported type %s for field %r; returning None",
+        type(value).__name__,
+        field_name,
+    )
+    return None
+
+
+def coerce_int(
+    value: Any,
+    field_name: str = "<unknown>",
+) -> int | None:
+    """Coerce an API field value to int, returning None when impossible.
+
+    Built on top of :func:`coerce_numeric`, so it handles the same input
+    shapes (int, float, numeric string, dict with a candidate key). A
+    fractional float is truncated toward zero.
+
+    Args:
+        value:      The raw value from the API response.
+        field_name: Name of the field being coerced (used in log messages).
+
+    Returns:
+        An ``int`` on success, or ``None`` when the value cannot be coerced.
+    """
+    numeric = coerce_numeric(value, field_name=field_name)
+    return int(numeric) if numeric is not None else None
+
+
+# Truthy / falsy string tokens recognised when coercing strings to bool.
+_TRUE_TOKENS = frozenset({"true", "1", "yes", "on", "enabled"})
+_FALSE_TOKENS = frozenset({"false", "0", "no", "off", "disabled", ""})
+
+# Ordered candidate keys to probe when coercing a dict to a bool.
+_BOOL_CANDIDATE_KEYS = ("enabled", "value", "available", "active")
+
+
+def coerce_bool(
+    value: Any,
+    field_name: str = "<unknown>",
+) -> bool | None:
+    """Coerce an API field value to bool, returning None when impossible.
+
+    Handles the following input shapes:
+
+    - ``bool``             → returned unchanged.
+    - ``int`` / ``float``  → ``bool(value)`` (``0`` is False, non-zero True).
+    - ``str``              → recognised truthy/falsy tokens (case-insensitive);
+                             unrecognised strings return None.
+    - ``dict``             → probe candidate keys in order
+                             (``enabled``, ``value``, ``available``,
+                             ``active``); if none match, a non-empty dict is
+                             treated as True (the structured value being
+                             present implies the feature is set).
+    - ``None`` / other     → return None.
+
+    Args:
+        value:      The raw value from the API response.
+        field_name: Name of the field being coerced (used in log messages).
+
+    Returns:
+        A ``bool`` on success, or ``None`` when the value cannot be coerced.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _TRUE_TOKENS:
+            return True
+        if token in _FALSE_TOKENS:
+            return False
+        _LOGGER.debug(
+            "coerce_bool: cannot parse string %r for field %r",
+            value,
+            field_name,
+        )
+        return None
+
+    if isinstance(value, dict):
+        for key in _BOOL_CANDIDATE_KEYS:
+            if key in value:
+                return coerce_bool(value[key], field_name=field_name)
+        # No known key — a populated structured value implies "set/enabled".
+        return bool(value)
+
+    _LOGGER.debug(
+        "coerce_bool: unsupported type %s for field %r; returning None",
         type(value).__name__,
         field_name,
     )

--- a/backend/app/routes/eeros.py
+++ b/backend/app/routes/eeros.py
@@ -2,18 +2,40 @@
 
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from eero import EeroClient
 from eero.exceptions import EeroException
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
-from .._coercion import coerce_numeric
+from .._coercion import coerce_int, coerce_numeric
 from ..deps import get_network_id, require_auth
 from ..transformers import check_success, extract_data, extract_list, normalize_eero
 
 router = APIRouter()
 _LOGGER = logging.getLogger(__name__)
+
+
+def _safe_str(value: Any) -> str:
+    """Coerce a value to a non-None string for required string fields.
+
+    Required ``str`` fields on the response models must never receive None
+    or a non-string value, otherwise model validation fails and the request
+    returns HTTP 500. This guarantees a plain string regardless of the raw
+    API value's shape.
+
+    Args:
+        value: Raw value from the (normalized) API response.
+
+    Returns:
+        The value as a string, or an empty string when it is None.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
 
 
 def calculate_uptime_seconds(last_reboot: str | None) -> int | None:
@@ -189,25 +211,40 @@ async def list_eeros(
         result = []
         for raw_eero in raw_eeros:
             eero = normalize_eero(raw_eero)
-            result.append(
-                EeroSummary(
-                    id=eero.get("id") or eero.get("serial") or "",
-                    url=eero.get("url") or "",
-                    serial=eero.get("serial") or "",
-                    mac_address=eero.get("mac_address") or "",
-                    model=eero.get("model") or "",
-                    status=eero.get("status") or "unknown",
-                    location=eero.get("location"),
-                    is_gateway=eero.get("is_gateway", False),
-                    is_primary=eero.get("is_primary", False),
-                    connected_clients_count=eero.get("connected_clients_count", 0),
-                    firmware_version=eero.get("firmware_version"),
-                    ip_address=eero.get("ip_address"),
-                    mesh_quality_bars=eero.get("mesh_quality_bars"),
-                    led_on=eero.get("led_on"),
-                    wired=eero.get("wired", False),
+            try:
+                result.append(
+                    EeroSummary(
+                        id=_safe_str(eero.get("id") or eero.get("serial")),
+                        url=_safe_str(eero.get("url")),
+                        serial=_safe_str(eero.get("serial")),
+                        mac_address=_safe_str(eero.get("mac_address")),
+                        model=_safe_str(eero.get("model")),
+                        status=eero.get("status") or "unknown",
+                        location=eero.get("location"),
+                        is_gateway=eero.get("is_gateway", False),
+                        is_primary=eero.get("is_primary", False),
+                        connected_clients_count=eero.get("connected_clients_count", 0),
+                        firmware_version=eero.get("firmware_version"),
+                        ip_address=eero.get("ip_address"),
+                        mesh_quality_bars=eero.get("mesh_quality_bars"),
+                        led_on=eero.get("led_on"),
+                        wired=eero.get("wired", False),
+                    )
                 )
-            )
+            except ValidationError as e:
+                # An unexpected response shape for one eero must not blank
+                # the entire list — degrade that entry to a minimal summary.
+                _LOGGER.error("Eero summary failed validation, degrading entry: %s", e)
+                result.append(
+                    EeroSummary(
+                        id=_safe_str(eero.get("id") or eero.get("serial")),
+                        url=_safe_str(eero.get("url")),
+                        serial=_safe_str(eero.get("serial")),
+                        mac_address=_safe_str(eero.get("mac_address")),
+                        model=_safe_str(eero.get("model")),
+                        status="unknown",
+                    )
+                )
 
         return result
     except EeroException as e:
@@ -238,7 +275,11 @@ async def get_eero(
         # Extract organization info
         org = eero.get("organization", {}) or {}
         organization_name = org.get("name") if isinstance(org, dict) else None
-        organization_id = org.get("id") if isinstance(org, dict) else None
+        organization_id = (
+            coerce_int(org.get("id"), field_name="organization_id")
+            if isinstance(org, dict)
+            else None
+        )
 
         # Extract power info
         power_info = eero.get("power_info", {}) or {}
@@ -259,20 +300,20 @@ async def get_eero(
         if last_heartbeat and hasattr(last_heartbeat, "isoformat"):
             last_heartbeat = last_heartbeat.isoformat()
 
-        # Format bssids_with_bands
+        # Format bssids_with_bands — keep only dict entries so the field
+        # always matches the declared list[dict] type.
         bssids_with_bands = eero.get("bssids_with_bands")
-        if bssids_with_bands and isinstance(bssids_with_bands, list):
+        if isinstance(bssids_with_bands, list):
             bssids_with_bands = [
-                (
-                    {
-                        "band": b.get("band"),
-                        "ethernet_address": b.get("ethernet_address"),
-                    }
-                    if isinstance(b, dict)
-                    else b
-                )
+                {
+                    "band": b.get("band"),
+                    "ethernet_address": b.get("ethernet_address"),
+                }
                 for b in bssids_with_bands
-            ]
+                if isinstance(b, dict)
+            ] or None
+        else:
+            bssids_with_bands = None
 
         # Format IPv6 addresses
         ipv6_addresses = eero.get("ipv6_addresses")
@@ -300,61 +341,81 @@ async def get_eero(
             else calculate_uptime_seconds(eero.get("last_reboot"))
         )
 
-        return EeroDetail(
-            id=eero.get("id") or eero.get("serial") or eero_id,
-            url=eero.get("url") or "",
-            serial=eero.get("serial") or "",
-            mac_address=eero.get("mac_address") or "",
-            model=eero.get("model") or "",
-            model_number=eero.get("model_number"),
-            status=eero.get("status") or "unknown",
-            state=eero.get("state"),
-            location=eero.get("location"),
-            is_gateway=eero.get("is_gateway", False),
-            is_primary=eero.get("is_primary", False),
-            wired=eero.get("wired", False),
-            connection_type=eero.get("connection_type"),
-            mesh_quality_bars=eero.get("mesh_quality_bars"),
-            ip_address=eero.get("ip_address"),
-            using_wan=eero.get("using_wan"),
-            connected_clients_count=eero.get("connected_clients_count", 0),
-            connected_wired_clients_count=eero.get("connected_wired_clients_count"),
-            connected_wireless_clients_count=eero.get(
-                "connected_wireless_clients_count"
-            ),
-            firmware_version=eero.get("firmware_version"),
-            os_version=eero.get("os_version"),
-            led_on=eero.get("led_on"),
-            led_brightness=eero.get("led_brightness"),
-            uptime=uptime_seconds,
-            cpu_usage=coerce_numeric(eero.get("cpu_usage"), field_name="cpu_usage"),
-            memory_usage=coerce_numeric(
-                eero.get("memory_usage"), field_name="memory_usage"
-            ),
-            temperature=coerce_numeric(
-                eero.get("temperature"), field_name="temperature"
-            ),
-            heartbeat_ok=eero.get("heartbeat_ok"),
-            update_available=eero.get("update_available"),
-            provides_wifi=eero.get("provides_wifi"),
-            auto_provisioned=eero.get("auto_provisioned"),
-            retrograde_capable=eero.get("retrograde_capable"),
-            last_heartbeat=last_heartbeat,
-            last_reboot=eero.get("last_reboot"),
-            joined=eero.get("joined"),
-            network_name=network_name,
-            network_url=network_url,
-            bands=eero.get("bands"),
-            wifi_bssids=eero.get("wifi_bssids"),
-            bssids_with_bands=bssids_with_bands,
-            ethernet_addresses=eero.get("ethernet_addresses"),
-            ethernet_ports=eero.get("ethernet_ports"),
-            ipv6_addresses=ipv6_addresses,
-            organization_name=organization_name,
-            organization_id=organization_id,
-            power_source=power_source,
-            power_saving_active=power_saving_active,
-        )
+        eero_id_value = _safe_str(eero.get("id") or eero.get("serial") or eero_id)
+
+        try:
+            return EeroDetail(
+                id=eero_id_value,
+                url=_safe_str(eero.get("url")),
+                serial=_safe_str(eero.get("serial")),
+                mac_address=_safe_str(eero.get("mac_address")),
+                model=_safe_str(eero.get("model")),
+                model_number=eero.get("model_number"),
+                status=eero.get("status") or "unknown",
+                state=eero.get("state"),
+                location=eero.get("location"),
+                is_gateway=eero.get("is_gateway", False),
+                is_primary=eero.get("is_primary", False),
+                wired=eero.get("wired", False),
+                connection_type=eero.get("connection_type"),
+                mesh_quality_bars=eero.get("mesh_quality_bars"),
+                ip_address=eero.get("ip_address"),
+                using_wan=eero.get("using_wan"),
+                connected_clients_count=eero.get("connected_clients_count", 0),
+                connected_wired_clients_count=eero.get("connected_wired_clients_count"),
+                connected_wireless_clients_count=eero.get(
+                    "connected_wireless_clients_count"
+                ),
+                firmware_version=eero.get("firmware_version"),
+                os_version=eero.get("os_version"),
+                led_on=eero.get("led_on"),
+                led_brightness=eero.get("led_brightness"),
+                uptime=uptime_seconds,
+                cpu_usage=coerce_numeric(eero.get("cpu_usage"), field_name="cpu_usage"),
+                memory_usage=coerce_numeric(
+                    eero.get("memory_usage"), field_name="memory_usage"
+                ),
+                temperature=coerce_numeric(
+                    eero.get("temperature"), field_name="temperature"
+                ),
+                heartbeat_ok=eero.get("heartbeat_ok"),
+                update_available=eero.get("update_available"),
+                provides_wifi=eero.get("provides_wifi"),
+                auto_provisioned=eero.get("auto_provisioned"),
+                retrograde_capable=eero.get("retrograde_capable"),
+                last_heartbeat=last_heartbeat,
+                last_reboot=eero.get("last_reboot"),
+                joined=eero.get("joined"),
+                network_name=network_name,
+                network_url=network_url,
+                bands=eero.get("bands"),
+                wifi_bssids=eero.get("wifi_bssids"),
+                bssids_with_bands=bssids_with_bands,
+                ethernet_addresses=eero.get("ethernet_addresses"),
+                ethernet_ports=eero.get("ethernet_ports"),
+                ipv6_addresses=ipv6_addresses,
+                organization_name=organization_name,
+                organization_id=organization_id,
+                power_source=power_source,
+                power_saving_active=power_saving_active,
+            )
+        except ValidationError as e:
+            # The Eero Cloud API returned a shape that does not match the
+            # EeroDetail model. Degrade gracefully to a minimal record
+            # instead of returning HTTP 500, so the detail page still loads.
+            _LOGGER.error(
+                "Eero %s response failed validation, returning degraded " "detail: %s",
+                eero_id,
+                e,
+            )
+            return EeroDetail(
+                id=eero_id_value,
+                url=_safe_str(eero.get("url")),
+                serial=_safe_str(eero.get("serial")),
+                mac_address=_safe_str(eero.get("mac_address")),
+                model=_safe_str(eero.get("model")),
+                status="unknown",
+            )
     except EeroException as e:
         _LOGGER.error(f"Failed to get eero {eero_id}: {e}")
         raise HTTPException(

--- a/backend/app/transformers.py
+++ b/backend/app/transformers.py
@@ -8,7 +8,27 @@ This module provides extraction and normalization functions.
 
 from typing import Any
 
-from ._coercion import coerce_numeric
+from ._coercion import coerce_bool, coerce_int, coerce_numeric
+
+
+def _as_str_list(value: Any) -> list[str] | None:
+    """Coerce a raw value into a list of strings, or None.
+
+    The Eero Cloud API normally returns ``bands``, ``wifi_bssids`` and
+    ``ethernet_addresses`` as flat string lists, but occasionally wraps the
+    entries in objects. Non-scalar entries are dropped so downstream model
+    validation (which expects ``list[str]``) never sees an unexpected shape.
+
+    Args:
+        value: Raw value from the API response.
+
+    Returns:
+        A list of strings, or None when there is no usable data.
+    """
+    if not isinstance(value, list):
+        return None
+    result = [str(item) for item in value if isinstance(item, (str, int, float))]
+    return result or None
 
 
 def extract_data(raw_response: Any) -> dict[str, Any]:
@@ -207,6 +227,17 @@ def normalize_network(raw: dict[str, Any]) -> dict[str, Any]:
     # Extract public_ip - may be in public_ip or wan_ip
     public_ip = raw.get("public_ip") or raw.get("wan_ip")
 
+    # Extract guest network status. The Eero Cloud API returns this as a
+    # nested object: {"guest_network": {"enabled": bool, "name": str, ...}}.
+    # Older/alternate shapes used flat top-level keys, so fall back to those.
+    guest_network = raw.get("guest_network")
+    if isinstance(guest_network, dict):
+        guest_network_enabled = bool(coerce_bool(guest_network.get("enabled")))
+        guest_network_name = guest_network.get("name")
+    else:
+        guest_network_enabled = bool(coerce_bool(raw.get("guest_network_enabled")))
+        guest_network_name = raw.get("guest_network_name")
+
     return {
         "id": net_id,
         "url": raw.get("url"),
@@ -214,8 +245,8 @@ def normalize_network(raw: dict[str, Any]) -> dict[str, Any]:
         "status": status,
         "isp_name": isp_name,
         "public_ip": public_ip,
-        "guest_network_enabled": raw.get("guest_network_enabled", False),
-        "guest_network_name": raw.get("guest_network_name"),
+        "guest_network_enabled": guest_network_enabled,
+        "guest_network_name": guest_network_name,
         "speed_test": raw.get("speed_test") or raw.get("speed"),
         "health": raw.get("health"),
         "settings": raw.get("settings"),
@@ -389,6 +420,12 @@ def normalize_eero(raw: dict[str, Any]) -> dict[str, Any]:
     if isinstance(location, dict):
         location = location.get("address") or location.get("name")
 
+    # Handle status as string or nested object ({"status": "green"}). The
+    # Eero Cloud API has been observed to return both shapes for eeros.
+    status = raw.get("status")
+    if isinstance(status, dict):
+        status = status.get("status")
+
     # Extract ethernet port info
     ethernet_ports = None
     ethernet_status = raw.get("ethernet_status", {})
@@ -421,43 +458,69 @@ def normalize_eero(raw: dict[str, Any]) -> dict[str, Any]:
         "mac_address": raw.get("mac_address"),
         "model": raw.get("model"),
         "model_number": raw.get("model_number"),
-        "status": raw.get("status"),
+        "status": status,
         "state": raw.get("state"),
         "location": location,
-        "is_gateway": raw.get("gateway", False) or raw.get("is_gateway", False),
-        "is_primary": raw.get("is_primary", False) or raw.get("is_primary_node", False),
-        "wired": raw.get("wired", False),
+        "is_gateway": bool(
+            coerce_bool(raw.get("gateway")) or coerce_bool(raw.get("is_gateway"))
+        ),
+        "is_primary": bool(
+            coerce_bool(raw.get("is_primary"))
+            or coerce_bool(raw.get("is_primary_node"))
+        ),
+        "wired": bool(coerce_bool(raw.get("wired"))),
         "connection_type": raw.get("connection_type"),
-        "mesh_quality_bars": raw.get("mesh_quality_bars"),
+        "mesh_quality_bars": coerce_int(
+            raw.get("mesh_quality_bars"), field_name="mesh_quality_bars"
+        ),
         "ip_address": raw.get("ip_address"),
-        "using_wan": raw.get("using_wan"),
-        "connected_clients_count": raw.get("connected_clients_count", 0),
-        "connected_wired_clients_count": raw.get("connected_wired_clients_count"),
-        "connected_wireless_clients_count": raw.get("connected_wireless_clients_count"),
+        "using_wan": coerce_bool(raw.get("using_wan"), field_name="using_wan"),
+        "connected_clients_count": coerce_int(
+            raw.get("connected_clients_count"), field_name="connected_clients_count"
+        )
+        or 0,
+        "connected_wired_clients_count": coerce_int(
+            raw.get("connected_wired_clients_count"),
+            field_name="connected_wired_clients_count",
+        ),
+        "connected_wireless_clients_count": coerce_int(
+            raw.get("connected_wireless_clients_count"),
+            field_name="connected_wireless_clients_count",
+        ),
         "firmware_version": raw.get("firmware_version")
         or raw.get("os_version")
         or raw.get("os"),
         "os_version": raw.get("os_version") or raw.get("os"),
-        "led_on": raw.get("led_on"),
-        "led_brightness": raw.get("led_brightness"),
+        "led_on": coerce_bool(raw.get("led_on"), field_name="led_on"),
+        "led_brightness": coerce_int(
+            raw.get("led_brightness"), field_name="led_brightness"
+        ),
         "uptime": coerce_numeric(raw.get("uptime"), field_name="uptime"),
         "cpu_usage": coerce_numeric(raw.get("cpu_usage"), field_name="cpu_usage"),
         "memory_usage": coerce_numeric(
             raw.get("memory_usage"), field_name="memory_usage"
         ),
         "temperature": coerce_numeric(raw.get("temperature"), field_name="temperature"),
-        "heartbeat_ok": raw.get("heartbeat_ok"),
-        "update_available": raw.get("update_available"),
-        "provides_wifi": raw.get("provides_wifi"),
-        "auto_provisioned": raw.get("auto_provisioned"),
-        "retrograde_capable": raw.get("retrograde_capable"),
+        "heartbeat_ok": coerce_bool(raw.get("heartbeat_ok"), field_name="heartbeat_ok"),
+        "update_available": coerce_bool(
+            raw.get("update_available"), field_name="update_available"
+        ),
+        "provides_wifi": coerce_bool(
+            raw.get("provides_wifi"), field_name="provides_wifi"
+        ),
+        "auto_provisioned": coerce_bool(
+            raw.get("auto_provisioned"), field_name="auto_provisioned"
+        ),
+        "retrograde_capable": coerce_bool(
+            raw.get("retrograde_capable"), field_name="retrograde_capable"
+        ),
         "last_heartbeat": raw.get("last_heartbeat"),
         "last_reboot": raw.get("last_reboot"),
         "joined": raw.get("joined"),
-        "bands": raw.get("bands"),
-        "wifi_bssids": raw.get("wifi_bssids"),
+        "bands": _as_str_list(raw.get("bands")),
+        "wifi_bssids": _as_str_list(raw.get("wifi_bssids")),
         "bssids_with_bands": raw.get("bssids_with_bands"),
-        "ethernet_addresses": raw.get("ethernet_addresses"),
+        "ethernet_addresses": _as_str_list(raw.get("ethernet_addresses")),
         "ethernet_ports": ethernet_ports,
         "ipv6_addresses": raw.get("ipv6_addresses"),
         "organization": raw.get("organization"),

--- a/backend/tests/test_coercion.py
+++ b/backend/tests/test_coercion.py
@@ -6,6 +6,8 @@ Tests cover:
 - Unknown dict shapes return None and log once (dedup)
 - Recursive dict coercion
 - Boolean inputs treated as non-numeric
+- coerce_int truncation and None passthrough
+- coerce_bool with bool, int, str tokens, dict shapes, and None
 """
 
 import logging
@@ -13,7 +15,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app._coercion import _UNKNOWN_DICT_LOGGED, coerce_numeric
+from app._coercion import (
+    _UNKNOWN_DICT_LOGGED,
+    coerce_bool,
+    coerce_int,
+    coerce_numeric,
+)
 
 # ========================== coerce_numeric Tests ==========================
 
@@ -267,3 +274,95 @@ class TestEerosRouteUptimeCoercion:
 
         assert response.status_code == 200
         assert response.json()["cpu_usage"] == pytest.approx(23.7)
+
+
+# ============================ coerce_int Tests ============================
+
+
+class TestCoerceInt:
+    """Tests for the coerce_int helper."""
+
+    def test_int_passthrough(self):
+        """A plain int is returned unchanged."""
+        assert coerce_int(42) == 42
+
+    def test_float_is_truncated(self):
+        """A float is truncated toward zero."""
+        assert coerce_int(75.9) == 75
+
+    def test_numeric_string(self):
+        """A numeric string is parsed."""
+        assert coerce_int("12") == 12
+
+    def test_dict_with_count_key(self):
+        """A dict shape is coerced via its candidate key."""
+        assert coerce_int({"count": 9}) == 9
+
+    def test_none_returns_none(self):
+        """None passes through as None."""
+        assert coerce_int(None) is None
+
+    def test_unknown_dict_returns_none(self):
+        """An unknown dict shape degrades to None."""
+        assert coerce_int({"bars": 3}) is None
+
+    def test_non_numeric_string_returns_none(self):
+        """A non-numeric string degrades to None."""
+        assert coerce_int("abc") is None
+
+
+# ============================ coerce_bool Tests ===========================
+
+
+class TestCoerceBool:
+    """Tests for the coerce_bool helper."""
+
+    def test_true_passthrough(self):
+        """A real bool is returned unchanged."""
+        assert coerce_bool(True) is True
+
+    def test_false_passthrough(self):
+        """A real False is returned unchanged."""
+        assert coerce_bool(False) is False
+
+    def test_none_returns_none(self):
+        """None passes through as None."""
+        assert coerce_bool(None) is None
+
+    def test_int_nonzero_is_true(self):
+        """A non-zero int is truthy."""
+        assert coerce_bool(1) is True
+
+    def test_int_zero_is_false(self):
+        """Zero is falsy."""
+        assert coerce_bool(0) is False
+
+    @pytest.mark.parametrize("token", ["true", "True", "1", "yes", "on", "enabled"])
+    def test_truthy_strings(self, token):
+        """Recognised truthy string tokens coerce to True."""
+        assert coerce_bool(token) is True
+
+    @pytest.mark.parametrize("token", ["false", "0", "no", "off", "disabled", ""])
+    def test_falsy_strings(self, token):
+        """Recognised falsy string tokens coerce to False."""
+        assert coerce_bool(token) is False
+
+    def test_unrecognised_string_returns_none(self):
+        """An unrecognised string degrades to None."""
+        assert coerce_bool("maybe") is None
+
+    def test_dict_with_enabled_key(self):
+        """A dict with an 'enabled' key is unwrapped."""
+        assert coerce_bool({"enabled": True}) is True
+
+    def test_non_empty_dict_without_known_key_is_true(self):
+        """A populated structured value implies the feature is set."""
+        assert coerce_bool({"min_required_firmware": "7.5.0"}) is True
+
+    def test_empty_dict_is_false(self):
+        """An empty dict coerces to False."""
+        assert coerce_bool({}) is False
+
+    def test_list_returns_none(self):
+        """An unsupported type degrades to None."""
+        assert coerce_bool(["x"]) is None

--- a/backend/tests/test_eeros.py
+++ b/backend/tests/test_eeros.py
@@ -1,0 +1,173 @@
+"""Tests for eero node routes.
+
+Covers the eero list and detail endpoints, with particular focus on the
+issue #193 regression: the detail endpoint must not return HTTP 500 when
+the Eero Cloud API returns fields in unexpected shapes.
+"""
+
+from unittest.mock import AsyncMock
+
+from eero.exceptions import EeroException
+
+
+def make_raw_response(data, code: int = 200):
+    """Helper to create a raw API response envelope."""
+    return {"meta": {"code": code}, "data": data}
+
+
+# A well-formed single-eero payload as returned by the Eero Cloud API.
+sample_eero = {
+    "url": "/2.2/eeros/eero-1",
+    "serial": "SN-EERO-1",
+    "mac_address": "AA:BB:CC:DD:EE:FF",
+    "model": "eero Pro 6E",
+    "model_number": "R010001",
+    "status": "green",
+    "location": "Office",
+    "gateway": True,
+    "os_version": "7.4.0",
+    "ip_address": "192.168.4.1",
+    "connected_clients_count": 12,
+    "led_on": True,
+    "update_available": False,
+    "last_reboot": "2026-05-01T08:30:00.000Z",
+}
+
+
+class TestListEeros:
+    """Tests for GET /api/eeros."""
+
+    async def test_list_eeros_success(self, auth_client, authenticated_client):
+        """Returns the list of eero nodes."""
+        authenticated_client.get_eeros = AsyncMock(
+            return_value=make_raw_response([sample_eero])
+        )
+
+        response = await auth_client.get("/api/eeros")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "eero-1"
+        assert data[0]["model"] == "eero Pro 6E"
+
+    async def test_list_eeros_empty(self, auth_client, authenticated_client):
+        """Returns an empty list when there are no eeros."""
+        authenticated_client.get_eeros = AsyncMock(return_value=make_raw_response([]))
+
+        response = await auth_client.get("/api/eeros")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_eeros_tolerates_malformed_entry(
+        self, auth_client, authenticated_client
+    ):
+        """A single malformed eero must not blank the whole list."""
+        malformed = {"url": "/2.2/eeros/eero-2", "status": {"deeply": {"nested": 1}}}
+        authenticated_client.get_eeros = AsyncMock(
+            return_value=make_raw_response([sample_eero, malformed])
+        )
+
+        response = await auth_client.get("/api/eeros")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+
+class TestGetEero:
+    """Tests for GET /api/eeros/{eero_id}."""
+
+    async def test_get_eero_success(self, auth_client, authenticated_client):
+        """Returns full eero detail for a well-formed response."""
+        authenticated_client.get_eero = AsyncMock(
+            return_value=make_raw_response(sample_eero)
+        )
+
+        response = await auth_client.get("/api/eeros/eero-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "eero-1"
+        assert data["status"] == "green"
+        assert data["is_gateway"] is True
+        assert data["connected_clients_count"] == 12
+
+    async def test_get_eero_nested_status_dict(self, auth_client, authenticated_client):
+        """Detail endpoint handles a nested status object without a 500."""
+        raw = {**sample_eero, "status": {"status": "green"}}
+        authenticated_client.get_eero = AsyncMock(return_value=make_raw_response(raw))
+
+        response = await auth_client.get("/api/eeros/eero-1")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "green"
+
+    async def test_get_eero_dict_shaped_numeric_fields(
+        self, auth_client, authenticated_client
+    ):
+        """Detail endpoint coerces dict-shaped numeric fields without a 500."""
+        raw = {
+            **sample_eero,
+            "connected_clients_count": {"count": 7},
+            "mesh_quality_bars": {"value": 3},
+        }
+        authenticated_client.get_eero = AsyncMock(return_value=make_raw_response(raw))
+
+        response = await auth_client.get("/api/eeros/eero-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connected_clients_count"] == 7
+        assert data["mesh_quality_bars"] == 3
+
+    async def test_get_eero_object_shaped_update_available(
+        self, auth_client, authenticated_client
+    ):
+        """Detail endpoint coerces an object-shaped update_available."""
+        raw = {**sample_eero, "update_available": {"min_required_firmware": "7.5"}}
+        authenticated_client.get_eero = AsyncMock(return_value=make_raw_response(raw))
+
+        response = await auth_client.get("/api/eeros/eero-1")
+
+        assert response.status_code == 200
+        assert response.json()["update_available"] is True
+
+    async def test_get_eero_malformed_response_degrades_gracefully(
+        self, auth_client, authenticated_client
+    ):
+        """A wholly unexpected response degrades to 200 instead of a 500."""
+        raw = {
+            "url": "/2.2/eeros/eero-1",
+            "serial": "SN-EERO-1",
+            "model": "eero",
+            "status": {"value": {"unexpected": "shape"}},
+            "bands": [{"band": "2.4"}],
+            "bssids_with_bands": ["not-a-dict"],
+        }
+        authenticated_client.get_eero = AsyncMock(return_value=make_raw_response(raw))
+
+        response = await auth_client.get("/api/eeros/eero-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["serial"] == "SN-EERO-1"
+
+    async def test_get_eero_not_found(self, auth_client, authenticated_client):
+        """An SDK error maps to a 404 response."""
+        authenticated_client.get_eero = AsyncMock(
+            side_effect=EeroException("not found")
+        )
+
+        response = await auth_client.get("/api/eeros/missing")
+
+        assert response.status_code == 404
+
+    async def test_get_eero_requires_auth(self, async_client, mock_eero_client):
+        """Unauthenticated requests are rejected."""
+        mock_eero_client.is_authenticated = False
+
+        response = await async_client.get("/api/eeros/eero-1")
+
+        assert response.status_code == 401

--- a/backend/tests/test_networks.py
+++ b/backend/tests/test_networks.py
@@ -54,6 +54,32 @@ class TestGetNetwork:
         assert data["name"] == "Home"
         assert data["status"] == "online"
 
+    async def test_get_network_guest_network_enabled(
+        self, auth_client, authenticated_client
+    ):
+        """Reports the guest network as enabled from the nested object.
+
+        Regression test for issue #194: the Eero Cloud API returns guest
+        network status as a nested ``guest_network`` object, not a flat
+        ``guest_network_enabled`` boolean.
+        """
+        network = {
+            "url": "/2.2/networks/net-1",
+            "name": "Home",
+            "status": "online",
+            "guest_network": {"enabled": True, "name": "Guest WiFi"},
+        }
+        authenticated_client.get_network = AsyncMock(
+            return_value=make_raw_response(network)
+        )
+        authenticated_client.get_devices = AsyncMock(return_value=make_raw_response([]))
+        authenticated_client.get_eeros = AsyncMock(return_value=make_raw_response([]))
+
+        response = await auth_client.get("/api/networks/net-1")
+
+        assert response.status_code == 200
+        assert response.json()["guest_network_enabled"] is True
+
 
 class TestRenameNetwork:
     """Tests for PUT /api/networks/{network_id}/name."""

--- a/backend/tests/test_transformers.py
+++ b/backend/tests/test_transformers.py
@@ -186,6 +186,38 @@ class TestNormalizeNetwork:
         result = normalize_network(raw)
         assert result["status"] == "online"
 
+    def test_guest_network_enabled_from_nested_object(self):
+        """Should read guest network status from the nested guest_network object.
+
+        The Eero Cloud API returns guest network status as a nested object:
+        {"guest_network": {"enabled": true, "name": "..."}}.
+        """
+        raw = {
+            "url": "/networks/1",
+            "guest_network": {"enabled": True, "name": "Guest WiFi"},
+        }
+        result = normalize_network(raw)
+        assert result["guest_network_enabled"] is True
+        assert result["guest_network_name"] == "Guest WiFi"
+
+    def test_guest_network_disabled_from_nested_object(self):
+        """Should report guest network disabled when nested enabled is False."""
+        raw = {"url": "/networks/1", "guest_network": {"enabled": False}}
+        result = normalize_network(raw)
+        assert result["guest_network_enabled"] is False
+
+    def test_guest_network_defaults_false_when_absent(self):
+        """Should default to False when no guest network data is present."""
+        raw = {"url": "/networks/1"}
+        result = normalize_network(raw)
+        assert result["guest_network_enabled"] is False
+
+    def test_guest_network_legacy_top_level_key(self):
+        """Should fall back to the legacy flat guest_network_enabled key."""
+        raw = {"url": "/networks/1", "guest_network_enabled": True}
+        result = normalize_network(raw)
+        assert result["guest_network_enabled"] is True
+
 
 class TestNormalizeDevice:
     """Tests for normalize_device function."""
@@ -281,6 +313,57 @@ class TestNormalizeEero:
         raw = {"url": "/eeros/1", "location": {"address": "Kitchen"}}
         result = normalize_eero(raw)
         assert result["location"] == "Kitchen"
+
+    def test_unwraps_nested_status_dict(self):
+        """Should unwrap a nested status object to a plain string."""
+        raw = {"url": "/eeros/1", "status": {"status": "green"}}
+        result = normalize_eero(raw)
+        assert result["status"] == "green"
+
+    def test_coerces_dict_shaped_client_counts(self):
+        """Should coerce dict-shaped numeric count fields to ints."""
+        raw = {
+            "url": "/eeros/1",
+            "connected_clients_count": {"count": 9},
+            "mesh_quality_bars": {"value": 4},
+        }
+        result = normalize_eero(raw)
+        assert result["connected_clients_count"] == 9
+        assert result["mesh_quality_bars"] == 4
+
+    def test_connected_clients_count_defaults_to_zero(self):
+        """Should default connected_clients_count to 0 when absent or null."""
+        assert normalize_eero({"url": "/eeros/1"})["connected_clients_count"] == 0
+        raw = {"url": "/eeros/1", "connected_clients_count": None}
+        assert normalize_eero(raw)["connected_clients_count"] == 0
+
+    def test_coerces_object_shaped_update_available(self):
+        """Should coerce an object-shaped update_available to a bool."""
+        raw = {"url": "/eeros/1", "update_available": {"min_firmware": "7.5"}}
+        assert normalize_eero(raw)["update_available"] is True
+
+    def test_coerces_string_booleans(self):
+        """Should coerce string boolean values to real booleans."""
+        raw = {"url": "/eeros/1", "led_on": "true", "heartbeat_ok": "false"}
+        result = normalize_eero(raw)
+        assert result["led_on"] is True
+        assert result["heartbeat_ok"] is False
+
+    def test_sanitizes_malformed_bands_list(self):
+        """Should drop non-scalar band entries so the value stays list[str]."""
+        raw = {"url": "/eeros/1", "bands": [{"band": "2.4"}, {"band": "5"}]}
+        assert normalize_eero(raw)["bands"] is None
+
+    def test_keeps_valid_string_lists(self):
+        """Should keep well-formed string lists unchanged."""
+        raw = {
+            "url": "/eeros/1",
+            "bands": ["2.4", "5"],
+            "ethernet_addresses": ["AA:BB:CC:DD:EE:FF"],
+        }
+        result = normalize_eero(raw)
+        assert result["bands"] == ["2.4", "5"]
+        assert result["ethernet_addresses"] == ["AA:BB:CC:DD:EE:FF"]
 
 
 class TestNormalizeProfile:


### PR DESCRIPTION
## Summary

Fixes two user-reported defects (#193, #194) that share a root cause: the backend mapped raw Eero Cloud API fields directly into strict Pydantic response models, so any field whose shape differed from the model's declared type broke the request. A comparable project (`eero-dashboard`) works against the same credentials, confirming the Eero cloud API is fine and `eero-ui` was mishandling the response.

Closes #193
Closes #194

## Issue #193 — Internal Server Error on eero detail view

**Root cause.** `GET /api/eeros/{eero_id}` constructs the strict `EeroDetail` model directly from raw API values. The Eero Cloud API returns several fields in variable shapes — `status` as a nested `{"status": "green"}` object, numeric counts (`connected_clients_count`, `mesh_quality_bars`, …) as dicts, `update_available` as an object. Any mismatch raised `pydantic.ValidationError`, which the route's `except EeroException` does **not** catch, so the global handler returned **HTTP 500**. The eeros *list* page kept working because `EeroSummary` is smaller and the offending fields are `EeroDetail`-only.

This is corroborated by `eero-prometheus-exporter` (works against the same API), which already coerces `connected_clients_count` / `mesh_quality_bars` numerically and unwraps a nested `status` — i.e. the real API genuinely returns these in inconsistent shapes.

**Fix.**
- `normalize_eero` now unwraps a nested `status`, coerces numeric count fields (`coerce_int`) and boolean fields (`coerce_bool`), and sanitises string-list fields (`bands`, `wifi_bssids`, `ethernet_addresses`).
- `GET /api/eeros/{id}` coerces the remaining direct extractions (`organization_id`, `bssids_with_bands`) and, as a final safety net, catches any residual `ValidationError` and returns a minimal record (status `unknown`) instead of a 500.
- `GET /api/eeros` degrades a single malformed node to a minimal summary rather than blanking the whole list.

## Issue #194 — Guest Network shown as disabled when it is enabled

**Root cause.** `normalize_network` read a flat `raw.get("guest_network_enabled", False)` key. The Eero Cloud API never sends that key — it returns a nested `guest_network` object: `{"enabled": true, "name": "…", …}` (confirmed by the `eero-api` test fixtures). The flat read therefore always evaluated to `False`.

**Fix.** `normalize_network` now reads `guest_network.enabled` / `guest_network.name` from the nested object, with the legacy flat key kept as a fallback. Both `NetworkSummary` and `NetworkDetail` pick this up automatically.

## Defensive handling

New `coerce_int` / `coerce_bool` helpers in `app/_coercion.py` (alongside the existing `coerce_numeric`) so unexpected or partial API responses degrade gracefully (to `None` / `unknown`) instead of throwing.

## Tests

- `test_coercion.py` — `coerce_int` / `coerce_bool` unit tests.
- `test_transformers.py` — nested `guest_network` mapping; `normalize_eero` status unwrap, dict-shaped counts, object-shaped `update_available`, malformed list sanitisation.
- `test_networks.py` — guest network reported enabled from the nested object.
- `test_eeros.py` (new) — detail endpoint success, nested status, dict-shaped numerics, object `update_available`, malformed-response graceful degradation, 404 on SDK error, auth required.

165 backend tests pass; `black`, `isort`, `ruff` all clean.

## Manual verification

Reproduced both bugs against the real per-eero / per-network response shapes (driven through the actual FastAPI routes with the `eero-api` SDK mocked at the boundary):

- **Before:** clicking an eero → `HTTP 500 {"detail": "Internal server error"}` for every malformed-shape variant; guest network → `guest_network_enabled: false`.
- **After:** every variant (well-formed and malformed) → `HTTP 200`, detail page renders; guest network → `guest_network_enabled: true` when the nested `guest_network.enabled` is `true`, `false` when disabled.

Steps to verify in a running instance: open the *Eeros* tab → click any eero node → the detail page loads instead of "Internal Server Error"; open a network → the Guest Network card shows **Enabled** when it is enabled in the official eero app.

## Scope

Backend only — `app/_coercion.py`, `app/transformers.py`, `app/routes/eeros.py` and tests. No frontend changes: response field names are unchanged, so the existing Svelte views consume the corrected data as-is.