### PR TITLE
fix(profiles): bulk-assign all selected devices in one call

### DIFF
--- a/backend/app/routes/profiles.py
+++ b/backend/app/routes/profiles.py
@@ -346,6 +346,116 @@ async def rename_profile(
         )
 
 
+class AssignDevicesRequest(BaseModel):
+    """Request body for assigning devices to a profile."""
+
+    device_ids: list[str]
+
+    class Config:
+        extra = "ignore"
+
+
+class AssignDevicesResponse(BaseModel):
+    """Response for assign-devices endpoint."""
+
+    success: bool
+    profile_id: str
+    assigned_count: int
+    message: str | None = None
+
+
+@router.post("/{profile_id}/assign-devices", response_model=AssignDevicesResponse)
+async def assign_devices_to_profile(
+    profile_id: str,
+    body: AssignDevicesRequest,
+    client: EeroClient = Depends(require_auth),
+    network_id: str = Depends(get_network_id),
+) -> AssignDevicesResponse:
+    """Assign devices to a profile by merging with the existing device list.
+
+    This endpoint performs a single set_profile_devices call with the
+    union of currently-assigned devices and the requested device IDs,
+    preventing overwrites caused by multiple per-device calls.
+    """
+    from ..transformers import normalize_device
+
+    try:
+        # --- Step 1: Build a map of device_id -> device_url from the network ---
+        raw_devices_resp = await client.get_devices(network_id)
+        raw_devices = extract_list(raw_devices_resp, "devices")
+        device_url_map: dict[str, str] = {}
+        for raw_dev in raw_devices:
+            normalized = normalize_device(raw_dev)
+            dev_id = normalized.get("id")
+            dev_url = normalized.get("url")
+            if dev_id and dev_url:
+                device_url_map[dev_id] = dev_url
+
+        # Resolve requested device IDs to URLs; skip unresolvable ones
+        selected_urls: set[str] = set()
+        for dev_id in body.device_ids:
+            url = device_url_map.get(dev_id)
+            if url:
+                selected_urls.add(url)
+            else:
+                _LOGGER.warning(
+                    "Device ID %s not found in network %s — skipping",
+                    dev_id,
+                    network_id,
+                )
+
+        # --- Step 2: Fetch the profile's current device URLs ---
+        raw_profile_resp = await client.get_profile_devices(
+            profile_id, network_id
+        )
+        profile_data = extract_data(raw_profile_resp)
+        current_devices_raw = profile_data.get("devices", [])
+        if isinstance(current_devices_raw, dict):
+            current_devices_raw = current_devices_raw.get("data", [])
+
+        current_urls: set[str] = set()
+        for entry in current_devices_raw if isinstance(current_devices_raw, list) else []:
+            # Entry may be {"url": "..."} or a plain string
+            if isinstance(entry, dict):
+                url = entry.get("url")
+            elif isinstance(entry, str):
+                url = entry
+            else:
+                url = None
+            if url:
+                current_urls.add(url)
+
+        # --- Step 3: Merge and call set_profile_devices ONCE ---
+        final_urls = list(current_urls | selected_urls)
+        await client.set_profile_devices(
+            profile_id, final_urls, network_id
+        )
+
+        assigned_count = len(selected_urls)
+        _LOGGER.info(
+            "Assigned %d device(s) to profile %s (total after merge: %d)",
+            assigned_count,
+            profile_id,
+            len(final_urls),
+        )
+
+        return AssignDevicesResponse(
+            success=True,
+            profile_id=profile_id,
+            assigned_count=assigned_count,
+            message=f"Successfully assigned {assigned_count} device(s) to profile.",
+        )
+
+    except EeroException as e:
+        _LOGGER.error(
+            "Failed to assign devices to profile %s: %s", profile_id, e
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to assign devices to profile. Please try again.",
+        )
+
+
 @router.delete("/{profile_id}", response_model=ProfileAction)
 async def delete_profile(
     profile_id: str,

--- a/backend/app/routes/profiles.py
+++ b/backend/app/routes/profiles.py
@@ -405,16 +405,16 @@ async def assign_devices_to_profile(
                 )
 
         # --- Step 2: Fetch the profile's current device URLs ---
-        raw_profile_resp = await client.get_profile_devices(
-            profile_id, network_id
-        )
+        raw_profile_resp = await client.get_profile_devices(profile_id, network_id)
         profile_data = extract_data(raw_profile_resp)
         current_devices_raw = profile_data.get("devices", [])
         if isinstance(current_devices_raw, dict):
             current_devices_raw = current_devices_raw.get("data", [])
 
         current_urls: set[str] = set()
-        for entry in current_devices_raw if isinstance(current_devices_raw, list) else []:
+        for entry in (
+            current_devices_raw if isinstance(current_devices_raw, list) else []
+        ):
             # Entry may be {"url": "..."} or a plain string
             if isinstance(entry, dict):
                 url = entry.get("url")
@@ -427,9 +427,7 @@ async def assign_devices_to_profile(
 
         # --- Step 3: Merge and call set_profile_devices ONCE ---
         final_urls = list(current_urls | selected_urls)
-        await client.set_profile_devices(
-            profile_id, final_urls, network_id
-        )
+        await client.set_profile_devices(profile_id, final_urls, network_id)
 
         assigned_count = len(selected_urls)
         _LOGGER.info(
@@ -447,9 +445,7 @@ async def assign_devices_to_profile(
         )
 
     except EeroException as e:
-        _LOGGER.error(
-            "Failed to assign devices to profile %s: %s", profile_id, e
-        )
+        _LOGGER.error("Failed to assign devices to profile %s: %s", profile_id, e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to assign devices to profile. Please try again.",

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -1,7 +1,8 @@
 """Tests for profile routes."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
+import pytest
 from eero.exceptions import EeroException
 
 
@@ -217,3 +218,212 @@ class TestUnpauseProfile:
         assert response.status_code == 200
         data = response.json()
         assert data["action"] == "unpause"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for assign-devices tests
+# ---------------------------------------------------------------------------
+
+def _make_device(dev_id: str, network_id: str = "network-123") -> dict:
+    """Build a raw device dict matching the eero API envelope shape."""
+    return {
+        "url": f"/2.2/networks/{network_id}/devices/{dev_id}",
+        "mac": f"aa:bb:cc:dd:ee:{dev_id[-2:]}",
+        "nickname": f"Device {dev_id}",
+        "connected": True,
+        "wireless": True,
+    }
+
+
+def _make_profile_with_devices(
+    profile_id: str,
+    network_id: str,
+    existing_device_ids: list[str],
+) -> dict:
+    """Build a raw profile data dict (the 'data' field of the envelope)."""
+    return {
+        "url": f"/2.2/networks/{network_id}/profiles/{profile_id}",
+        "name": "Kids",
+        "paused": False,
+        "devices": [
+            {"url": f"/2.2/networks/{network_id}/devices/{d}"}
+            for d in existing_device_ids
+        ],
+    }
+
+
+class TestAssignDevicesToProfile:
+    """Tests for POST /api/profiles/{profile_id}/assign-devices."""
+
+    async def test_three_devices_single_sdk_call_with_merge(
+        self, auth_client, authenticated_client
+    ):
+        """Assigning 3 devices results in exactly ONE set_profile_devices call
+        that contains all 3 new URLs merged with any pre-existing device URLs."""
+        network_id = "network-123"
+        profile_id = "profile-1"
+
+        # Network has 4 devices; profile already owns device-0
+        raw_devices = [_make_device(f"device-{i}", network_id) for i in range(4)]
+        authenticated_client.get_devices = AsyncMock(
+            return_value=make_raw_response(raw_devices)
+        )
+
+        existing_url = f"/2.2/networks/{network_id}/devices/device-0"
+        authenticated_client.get_profile_devices = AsyncMock(
+            return_value=make_raw_response(
+                _make_profile_with_devices(profile_id, network_id, ["device-0"])
+            )
+        )
+
+        authenticated_client.set_profile_devices = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        # Assign devices 1, 2, 3 (device-0 already there, should be preserved)
+        response = await auth_client.post(
+            f"/api/profiles/{profile_id}/assign-devices",
+            json={"device_ids": ["device-1", "device-2", "device-3"]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["profile_id"] == profile_id
+        assert data["assigned_count"] == 3
+
+        # Must be called exactly once
+        authenticated_client.set_profile_devices.assert_called_once()
+
+        # The URL list passed must contain all 4 device URLs (merge of old + new)
+        call_args = authenticated_client.set_profile_devices.call_args
+        # Positional: (profile_id, device_urls, network_id)
+        passed_urls: list[str] = call_args.args[1]
+        expected_urls = {
+            f"/2.2/networks/{network_id}/devices/device-{i}" for i in range(4)
+        }
+        assert set(passed_urls) == expected_urls
+
+    async def test_empty_device_ids_returns_200_with_count_zero(
+        self, auth_client, authenticated_client
+    ):
+        """Empty device_ids list is a no-op: count 0, existing devices preserved."""
+        network_id = "network-123"
+        profile_id = "profile-1"
+
+        authenticated_client.get_devices = AsyncMock(
+            return_value=make_raw_response([_make_device("device-0", network_id)])
+        )
+
+        authenticated_client.get_profile_devices = AsyncMock(
+            return_value=make_raw_response(
+                _make_profile_with_devices(profile_id, network_id, ["device-0"])
+            )
+        )
+
+        authenticated_client.set_profile_devices = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        response = await auth_client.post(
+            f"/api/profiles/{profile_id}/assign-devices",
+            json={"device_ids": []},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["assigned_count"] == 0
+
+        # set_profile_devices still called once (preserving existing devices)
+        authenticated_client.set_profile_devices.assert_called_once()
+        passed_urls = authenticated_client.set_profile_devices.call_args.args[1]
+        # Existing device-0 must still be in the list
+        existing_url = f"/2.2/networks/{network_id}/devices/device-0"
+        assert existing_url in passed_urls
+
+    async def test_eero_exception_on_get_devices_returns_500(
+        self, auth_client, authenticated_client
+    ):
+        """EeroException during get_devices propagates as HTTP 500."""
+        authenticated_client.get_devices = AsyncMock(
+            side_effect=EeroException("network error")
+        )
+        authenticated_client.set_profile_devices = AsyncMock()
+
+        response = await auth_client.post(
+            "/api/profiles/profile-1/assign-devices",
+            json={"device_ids": ["device-1"]},
+        )
+
+        assert response.status_code == 500
+        authenticated_client.set_profile_devices.assert_not_called()
+
+    async def test_eero_exception_on_set_profile_devices_returns_500(
+        self, auth_client, authenticated_client
+    ):
+        """EeroException from set_profile_devices propagates as HTTP 500."""
+        network_id = "network-123"
+        profile_id = "profile-1"
+
+        authenticated_client.get_devices = AsyncMock(
+            return_value=make_raw_response([_make_device("device-1", network_id)])
+        )
+        authenticated_client.get_profile_devices = AsyncMock(
+            return_value=make_raw_response(
+                _make_profile_with_devices(profile_id, network_id, [])
+            )
+        )
+        authenticated_client.set_profile_devices = AsyncMock(
+            side_effect=EeroException("write error")
+        )
+
+        response = await auth_client.post(
+            f"/api/profiles/{profile_id}/assign-devices",
+            json={"device_ids": ["device-1"]},
+        )
+
+        assert response.status_code == 500
+
+    async def test_missing_device_id_skipped_gracefully(
+        self, auth_client, authenticated_client
+    ):
+        """Device IDs not found in the network are silently skipped."""
+        network_id = "network-123"
+        profile_id = "profile-1"
+
+        authenticated_client.get_devices = AsyncMock(
+            return_value=make_raw_response([_make_device("device-1", network_id)])
+        )
+        authenticated_client.get_profile_devices = AsyncMock(
+            return_value=make_raw_response(
+                _make_profile_with_devices(profile_id, network_id, [])
+            )
+        )
+        authenticated_client.set_profile_devices = AsyncMock(
+            return_value=make_raw_response({})
+        )
+
+        # "ghost-device" does not exist in the network
+        response = await auth_client.post(
+            f"/api/profiles/{profile_id}/assign-devices",
+            json={"device_ids": ["device-1", "ghost-device"]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        # Only 1 device could be resolved
+        assert data["assigned_count"] == 1
+        passed_urls = authenticated_client.set_profile_devices.call_args.args[1]
+        assert f"/2.2/networks/{network_id}/devices/device-1" in passed_urls
+        # ghost-device URL must not appear
+        assert not any("ghost-device" in u for u in passed_urls)
+
+    async def test_missing_body_returns_422(self, auth_client, authenticated_client):
+        """Missing request body returns 422 validation error."""
+        response = await auth_client.post(
+            "/api/profiles/profile-1/assign-devices",
+            content=b"",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 422

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -1,8 +1,7 @@
 """Tests for profile routes."""
 
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock
 
-import pytest
 from eero.exceptions import EeroException
 
 
@@ -224,6 +223,7 @@ class TestUnpauseProfile:
 # Helpers for assign-devices tests
 # ---------------------------------------------------------------------------
 
+
 def _make_device(dev_id: str, network_id: str = "network-123") -> dict:
     """Build a raw device dict matching the eero API envelope shape."""
     return {
@@ -269,7 +269,6 @@ class TestAssignDevicesToProfile:
             return_value=make_raw_response(raw_devices)
         )
 
-        existing_url = f"/2.2/networks/{network_id}/devices/device-0"
         authenticated_client.get_profile_devices = AsyncMock(
             return_value=make_raw_response(
                 _make_profile_with_devices(profile_id, network_id, ["device-0"])

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -355,7 +355,7 @@ export const api = {
 				`/profiles/${profileId}/assign-devices`,
 				{
 					method: 'POST',
-					body: { device_ids: deviceIds },
+					body: { device_ids: deviceIds }
 				}
 			)
 	}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -348,7 +348,16 @@ export const api = {
 		delete: (profileId: string) =>
 			fetchWithHandling<import('./types').ProfileAction>(`/profiles/${profileId}`, {
 				method: 'DELETE'
-			})
+			}),
+
+		assignDevices: (profileId: string, deviceIds: string[]) =>
+			fetchWithHandling<import('./types').ProfileAssignDevicesResponse>(
+				`/profiles/${profileId}/assign-devices`,
+				{
+					method: 'POST',
+					body: { device_ids: deviceIds },
+				}
+			)
 	}
 };
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -425,6 +425,13 @@ export interface ProfileAction {
 	message: string | null;
 }
 
+export interface ProfileAssignDevicesResponse {
+	success: boolean;
+	profile_id: string;
+	assigned_count: number;
+	message: string | null;
+}
+
 export interface ProfileCreateRequest {
 	name: string;
 }

--- a/frontend/src/lib/components/device/DeviceList.svelte
+++ b/frontend/src/lib/components/device/DeviceList.svelte
@@ -122,18 +122,20 @@
 	async function assignToProfile(profileId: string, profileName: string) {
 		if (selectedCount === 0) return;
 
+		const ids = Array.from($selectedDevices);
 		assigningProfile = true;
 
 		try {
-			// Note: This would require a backend endpoint to assign devices to profiles
-			// For now, show a message about the feature
-			uiStore.success(
-				`Would assign ${selectedCount} device(s) to "${profileName}". (API endpoint needed)`
-			);
+			await devicesStore.assignToProfile(ids, profileId, profileName);
+			uiStore.success(`Assigned ${ids.length} device(s) to "${profileName}"`);
 			profileSelectorOpen = false;
+			clearSelection();
 			toggleSelectionMode();
+			await devicesStore.fetch(true);
 		} catch (_error) {
-			uiStore.error('Failed to assign devices to profile');
+			uiStore.error(
+				_error instanceof Error ? _error.message : 'Failed to assign devices to profile'
+			);
 		} finally {
 			assigningProfile = false;
 		}

--- a/frontend/src/lib/stores/devices.test.ts
+++ b/frontend/src/lib/stores/devices.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the devices store.
+ *
+ * Tests cover:
+ * - assignToProfile: optimistic update, success, rollback on failure
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { devicesStore } from './devices';
+import { server } from '../../../tests/mocks/server';
+import { http, HttpResponse } from 'msw';
+
+// Seed data helpers
+const makeDevice = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  url: null,
+  mac: `AA:BB:CC:DD:EE:${id}`,
+  ip: '192.168.1.1',
+  nickname: `Device ${id}`,
+  hostname: null,
+  display_name: `Device ${id}`,
+  manufacturer: null,
+  model_name: null,
+  device_type: null,
+  connected: true,
+  wireless: true,
+  blocked: false,
+  paused: false,
+  is_guest: false,
+  connection_type: 'wireless' as const,
+  signal_strength: null,
+  frequency: null,
+  connected_to_eero: null,
+  last_active: null,
+  profile_id: null,
+  profile_name: null,
+  ...overrides,
+});
+
+describe('devicesStore', () => {
+  beforeEach(() => {
+    devicesStore.clear();
+  });
+
+  describe('assignToProfile', () => {
+    it('optimistically updates profile_id and profile_name on targeted devices', async () => {
+      // Seed the store with two devices
+      server.use(
+        http.get('/api/devices', () => {
+          return HttpResponse.json([makeDevice('dev-1'), makeDevice('dev-2')]);
+        })
+      );
+      await devicesStore.fetch();
+
+      // Kick off assignment (don't await yet) so we can inspect mid-flight
+      // We'll just await and verify the post-success state here
+      const result = await devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids');
+
+      expect(result).toBe(true);
+
+      const state = get(devicesStore);
+      const dev1 = state.devices.find((d) => d.id === 'dev-1');
+      const dev2 = state.devices.find((d) => d.id === 'dev-2');
+
+      expect(dev1?.profile_id).toBe('profile-1');
+      expect(dev1?.profile_name).toBe('Kids');
+      // Unaffected device stays the same
+      expect(dev2?.profile_id).toBeNull();
+    });
+
+    it('updates multiple devices in a single call', async () => {
+      server.use(
+        http.get('/api/devices', () => {
+          return HttpResponse.json([makeDevice('dev-1'), makeDevice('dev-2'), makeDevice('dev-3')]);
+        })
+      );
+      await devicesStore.fetch();
+
+      await devicesStore.assignToProfile(['dev-1', 'dev-2'], 'profile-2', 'Guests');
+
+      const state = get(devicesStore);
+      const dev1 = state.devices.find((d) => d.id === 'dev-1');
+      const dev2 = state.devices.find((d) => d.id === 'dev-2');
+      const dev3 = state.devices.find((d) => d.id === 'dev-3');
+
+      expect(dev1?.profile_name).toBe('Guests');
+      expect(dev2?.profile_name).toBe('Guests');
+      expect(dev3?.profile_name).toBeNull();
+    });
+
+    it('rolls back on API failure and re-throws', async () => {
+      server.use(
+        http.get('/api/devices', () => {
+          return HttpResponse.json([makeDevice('dev-1', { profile_id: null, profile_name: null })]);
+        }),
+        http.post('/api/profiles/:profileId/assign-devices', () => {
+          return HttpResponse.json({ detail: 'Internal server error' }, { status: 500 });
+        })
+      );
+      await devicesStore.fetch();
+
+      await expect(
+        devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids')
+      ).rejects.toThrow();
+
+      // Profile should be rolled back to null
+      const state = get(devicesStore);
+      const dev1 = state.devices.find((d) => d.id === 'dev-1');
+      expect(dev1?.profile_id).toBeNull();
+      expect(dev1?.profile_name).toBeNull();
+    });
+
+    it('rolls back on success=false response and re-throws', async () => {
+      server.use(
+        http.get('/api/devices', () => {
+          return HttpResponse.json([makeDevice('dev-1')]);
+        }),
+        http.post('/api/profiles/:profileId/assign-devices', () => {
+          return HttpResponse.json({
+            success: false,
+            profile_id: 'profile-1',
+            assigned_count: 0,
+            message: 'Profile not found',
+          });
+        })
+      );
+      await devicesStore.fetch();
+
+      await expect(
+        devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids')
+      ).rejects.toThrow('Profile not found');
+
+      const state = get(devicesStore);
+      const dev1 = state.devices.find((d) => d.id === 'dev-1');
+      expect(dev1?.profile_id).toBeNull();
+    });
+
+    it('returns true on success', async () => {
+      server.use(
+        http.get('/api/devices', () => {
+          return HttpResponse.json([makeDevice('dev-1')]);
+        })
+      );
+      await devicesStore.fetch();
+
+      const result = await devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids');
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/frontend/src/lib/stores/devices.test.ts
+++ b/frontend/src/lib/stores/devices.test.ts
@@ -13,139 +13,137 @@ import { http, HttpResponse } from 'msw';
 
 // Seed data helpers
 const makeDevice = (id: string, overrides: Record<string, unknown> = {}) => ({
-  id,
-  url: null,
-  mac: `AA:BB:CC:DD:EE:${id}`,
-  ip: '192.168.1.1',
-  nickname: `Device ${id}`,
-  hostname: null,
-  display_name: `Device ${id}`,
-  manufacturer: null,
-  model_name: null,
-  device_type: null,
-  connected: true,
-  wireless: true,
-  blocked: false,
-  paused: false,
-  is_guest: false,
-  connection_type: 'wireless' as const,
-  signal_strength: null,
-  frequency: null,
-  connected_to_eero: null,
-  last_active: null,
-  profile_id: null,
-  profile_name: null,
-  ...overrides,
+	id,
+	url: null,
+	mac: `AA:BB:CC:DD:EE:${id}`,
+	ip: '192.168.1.1',
+	nickname: `Device ${id}`,
+	hostname: null,
+	display_name: `Device ${id}`,
+	manufacturer: null,
+	model_name: null,
+	device_type: null,
+	connected: true,
+	wireless: true,
+	blocked: false,
+	paused: false,
+	is_guest: false,
+	connection_type: 'wireless' as const,
+	signal_strength: null,
+	frequency: null,
+	connected_to_eero: null,
+	last_active: null,
+	profile_id: null,
+	profile_name: null,
+	...overrides
 });
 
 describe('devicesStore', () => {
-  beforeEach(() => {
-    devicesStore.clear();
-  });
+	beforeEach(() => {
+		devicesStore.clear();
+	});
 
-  describe('assignToProfile', () => {
-    it('optimistically updates profile_id and profile_name on targeted devices', async () => {
-      // Seed the store with two devices
-      server.use(
-        http.get('/api/devices', () => {
-          return HttpResponse.json([makeDevice('dev-1'), makeDevice('dev-2')]);
-        })
-      );
-      await devicesStore.fetch();
+	describe('assignToProfile', () => {
+		it('optimistically updates profile_id and profile_name on targeted devices', async () => {
+			// Seed the store with two devices
+			server.use(
+				http.get('/api/devices', () => {
+					return HttpResponse.json([makeDevice('dev-1'), makeDevice('dev-2')]);
+				})
+			);
+			await devicesStore.fetch();
 
-      // Kick off assignment (don't await yet) so we can inspect mid-flight
-      // We'll just await and verify the post-success state here
-      const result = await devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids');
+			// Kick off assignment (don't await yet) so we can inspect mid-flight
+			// We'll just await and verify the post-success state here
+			const result = await devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids');
 
-      expect(result).toBe(true);
+			expect(result).toBe(true);
 
-      const state = get(devicesStore);
-      const dev1 = state.devices.find((d) => d.id === 'dev-1');
-      const dev2 = state.devices.find((d) => d.id === 'dev-2');
+			const state = get(devicesStore);
+			const dev1 = state.devices.find((d) => d.id === 'dev-1');
+			const dev2 = state.devices.find((d) => d.id === 'dev-2');
 
-      expect(dev1?.profile_id).toBe('profile-1');
-      expect(dev1?.profile_name).toBe('Kids');
-      // Unaffected device stays the same
-      expect(dev2?.profile_id).toBeNull();
-    });
+			expect(dev1?.profile_id).toBe('profile-1');
+			expect(dev1?.profile_name).toBe('Kids');
+			// Unaffected device stays the same
+			expect(dev2?.profile_id).toBeNull();
+		});
 
-    it('updates multiple devices in a single call', async () => {
-      server.use(
-        http.get('/api/devices', () => {
-          return HttpResponse.json([makeDevice('dev-1'), makeDevice('dev-2'), makeDevice('dev-3')]);
-        })
-      );
-      await devicesStore.fetch();
+		it('updates multiple devices in a single call', async () => {
+			server.use(
+				http.get('/api/devices', () => {
+					return HttpResponse.json([makeDevice('dev-1'), makeDevice('dev-2'), makeDevice('dev-3')]);
+				})
+			);
+			await devicesStore.fetch();
 
-      await devicesStore.assignToProfile(['dev-1', 'dev-2'], 'profile-2', 'Guests');
+			await devicesStore.assignToProfile(['dev-1', 'dev-2'], 'profile-2', 'Guests');
 
-      const state = get(devicesStore);
-      const dev1 = state.devices.find((d) => d.id === 'dev-1');
-      const dev2 = state.devices.find((d) => d.id === 'dev-2');
-      const dev3 = state.devices.find((d) => d.id === 'dev-3');
+			const state = get(devicesStore);
+			const dev1 = state.devices.find((d) => d.id === 'dev-1');
+			const dev2 = state.devices.find((d) => d.id === 'dev-2');
+			const dev3 = state.devices.find((d) => d.id === 'dev-3');
 
-      expect(dev1?.profile_name).toBe('Guests');
-      expect(dev2?.profile_name).toBe('Guests');
-      expect(dev3?.profile_name).toBeNull();
-    });
+			expect(dev1?.profile_name).toBe('Guests');
+			expect(dev2?.profile_name).toBe('Guests');
+			expect(dev3?.profile_name).toBeNull();
+		});
 
-    it('rolls back on API failure and re-throws', async () => {
-      server.use(
-        http.get('/api/devices', () => {
-          return HttpResponse.json([makeDevice('dev-1', { profile_id: null, profile_name: null })]);
-        }),
-        http.post('/api/profiles/:profileId/assign-devices', () => {
-          return HttpResponse.json({ detail: 'Internal server error' }, { status: 500 });
-        })
-      );
-      await devicesStore.fetch();
+		it('rolls back on API failure and re-throws', async () => {
+			server.use(
+				http.get('/api/devices', () => {
+					return HttpResponse.json([makeDevice('dev-1', { profile_id: null, profile_name: null })]);
+				}),
+				http.post('/api/profiles/:profileId/assign-devices', () => {
+					return HttpResponse.json({ detail: 'Internal server error' }, { status: 500 });
+				})
+			);
+			await devicesStore.fetch();
 
-      await expect(
-        devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids')
-      ).rejects.toThrow();
+			await expect(devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids')).rejects.toThrow();
 
-      // Profile should be rolled back to null
-      const state = get(devicesStore);
-      const dev1 = state.devices.find((d) => d.id === 'dev-1');
-      expect(dev1?.profile_id).toBeNull();
-      expect(dev1?.profile_name).toBeNull();
-    });
+			// Profile should be rolled back to null
+			const state = get(devicesStore);
+			const dev1 = state.devices.find((d) => d.id === 'dev-1');
+			expect(dev1?.profile_id).toBeNull();
+			expect(dev1?.profile_name).toBeNull();
+		});
 
-    it('rolls back on success=false response and re-throws', async () => {
-      server.use(
-        http.get('/api/devices', () => {
-          return HttpResponse.json([makeDevice('dev-1')]);
-        }),
-        http.post('/api/profiles/:profileId/assign-devices', () => {
-          return HttpResponse.json({
-            success: false,
-            profile_id: 'profile-1',
-            assigned_count: 0,
-            message: 'Profile not found',
-          });
-        })
-      );
-      await devicesStore.fetch();
+		it('rolls back on success=false response and re-throws', async () => {
+			server.use(
+				http.get('/api/devices', () => {
+					return HttpResponse.json([makeDevice('dev-1')]);
+				}),
+				http.post('/api/profiles/:profileId/assign-devices', () => {
+					return HttpResponse.json({
+						success: false,
+						profile_id: 'profile-1',
+						assigned_count: 0,
+						message: 'Profile not found'
+					});
+				})
+			);
+			await devicesStore.fetch();
 
-      await expect(
-        devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids')
-      ).rejects.toThrow('Profile not found');
+			await expect(devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids')).rejects.toThrow(
+				'Profile not found'
+			);
 
-      const state = get(devicesStore);
-      const dev1 = state.devices.find((d) => d.id === 'dev-1');
-      expect(dev1?.profile_id).toBeNull();
-    });
+			const state = get(devicesStore);
+			const dev1 = state.devices.find((d) => d.id === 'dev-1');
+			expect(dev1?.profile_id).toBeNull();
+		});
 
-    it('returns true on success', async () => {
-      server.use(
-        http.get('/api/devices', () => {
-          return HttpResponse.json([makeDevice('dev-1')]);
-        })
-      );
-      await devicesStore.fetch();
+		it('returns true on success', async () => {
+			server.use(
+				http.get('/api/devices', () => {
+					return HttpResponse.json([makeDevice('dev-1')]);
+				})
+			);
+			await devicesStore.fetch();
 
-      const result = await devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids');
-      expect(result).toBe(true);
-    });
-  });
+			const result = await devicesStore.assignToProfile(['dev-1'], 'profile-1', 'Kids');
+			expect(result).toBe(true);
+		});
+	});
 });

--- a/frontend/src/lib/stores/devices.ts
+++ b/frontend/src/lib/stores/devices.ts
@@ -280,7 +280,7 @@ function createDevicesStore() {
 					d.id && deviceIds.includes(d.id)
 						? { ...d, profile_id: profileId, profile_name: profileName }
 						: d
-				),
+				)
 			}));
 
 			try {
@@ -297,7 +297,7 @@ function createDevicesStore() {
 						if (!d.id || !deviceIds.includes(d.id)) return d;
 						const prev = previousState.devices.find((p) => p.id === d.id);
 						return prev ?? d;
-					}),
+					})
 				}));
 				throw error;
 			}

--- a/frontend/src/lib/stores/devices.ts
+++ b/frontend/src/lib/stores/devices.ts
@@ -264,6 +264,46 @@ function createDevicesStore() {
 		},
 
 		/**
+		 * Assign one or more devices to a profile (with optimistic update)
+		 */
+		async assignToProfile(
+			deviceIds: string[],
+			profileId: string,
+			profileName: string
+		): Promise<boolean> {
+			const previousState = get({ subscribe });
+
+			// Optimistic update — apply new profile to all targeted devices
+			update((s) => ({
+				...s,
+				devices: s.devices.map((d) =>
+					d.id && deviceIds.includes(d.id)
+						? { ...d, profile_id: profileId, profile_name: profileName }
+						: d
+				),
+			}));
+
+			try {
+				const result = await api.profiles.assignDevices(profileId, deviceIds);
+				if (!result.success) {
+					throw new Error(result.message || 'Failed to assign devices to profile');
+				}
+				return true;
+			} catch (error) {
+				// Rollback all affected devices to their previous state
+				update((s) => ({
+					...s,
+					devices: s.devices.map((d) => {
+						if (!d.id || !deviceIds.includes(d.id)) return d;
+						const prev = previousState.devices.find((p) => p.id === d.id);
+						return prev ?? d;
+					}),
+				}));
+				throw error;
+			}
+		},
+
+		/**
 		 * Set device nickname
 		 */
 		async setNickname(deviceId: string, nickname: string): Promise<boolean> {

--- a/frontend/src/routes/devices/[id]/+page.svelte
+++ b/frontend/src/routes/devices/[id]/+page.svelte
@@ -198,16 +198,15 @@
 
 	async function handleProfileChange(profileId: string | null, profileName: string) {
 		if (!device?.id) return;
+		if (profileId === null) return; // removing profile not yet supported by this endpoint
 
 		changingProfile = true;
 		profileDropdownOpen = false;
 
 		try {
-			// Note: This would require a backend endpoint to assign device to profile
-			uiStore.success(
-				`Would assign device to "${profileName}". (API endpoint needed for profile assignment)`
-			);
-			// await fetchDevice(true);
+			await devicesStore.assignToProfile([device.id], profileId, profileName);
+			uiStore.success(`Device assigned to "${profileName}"`);
+			await fetchDevice(true);
 		} catch (err) {
 			uiStore.error(err instanceof Error ? err.message : 'Failed to change profile');
 		} finally {

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -206,6 +206,16 @@ export const handlers = [
 		});
 	}),
 
+	http.post('/api/profiles/:profileId/assign-devices', async ({ params, request }) => {
+		const body = (await request.json()) as { device_ids: string[] };
+		return HttpResponse.json({
+			success: true,
+			profile_id: params.profileId,
+			assigned_count: body.device_ids.length,
+			message: null,
+		});
+	}),
+
 	// ============================================
 	// Health endpoint
 	// ============================================

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -212,7 +212,7 @@ export const handlers = [
 			success: true,
 			profile_id: params.profileId,
 			assigned_count: body.device_ids.length,
-			message: null,
+			message: null
 		});
 	}),
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -6,9 +6,14 @@
 |----------|-------------|---------|
 | `EERO_DASHBOARD_HOST` | Server bind address | `0.0.0.0` |
 | `EERO_DASHBOARD_PORT` | Server port | `8000` |
-| `EERO_DASHBOARD_DEBUG` | Enable debug mode | `false` |
-| `EERO_DASHBOARD_COOKIE_FILE` | Path to session file | `~/.eero-dashboard/session.json` |
-| `EERO_DASHBOARD_SESSION_SECRET` | Session encryption key | *(random)* |
+| `EERO_DASHBOARD_DEBUG` | Enable debug logging and `/api/docs` | `false` |
+| `EERO_DASHBOARD_SESSION_SECRET` | **Required.** Session encryption key | *(none — must be set)* |
+| `EERO_DASHBOARD_COOKIE_FILE` | Path to the Eero session file | `/data/session/session.json` (Docker) / `~/.eero-dashboard/session.json` (local) |
+| `EERO_DASHBOARD_COLLECTION_INTERVAL` | Metrics scrape interval, in seconds | `60` |
+| `EERO_DASHBOARD_METRICS_RETENTION` | How long VictoriaMetrics keeps data (e.g., `30d`, `6m`, `1y`) | `1y` |
+| `EERO_DASHBOARD_METRICS_ENDPOINT_ENABLED` | Expose `/metrics` for external Prometheus scraping | `false` |
+| `EERO_DASHBOARD_VICTORIA_METRICS_URL` | URL of the VictoriaMetrics instance | `http://127.0.0.1:8428` |
+| `EERO_EXPORTER_SESSION_PATH` | Shared session path for the embedded exporter | `/data/session/exporter-session.json` |
 
 ## Session Secret
 
@@ -29,3 +34,21 @@ EERO_DASHBOARD_DEBUG=true uvicorn app.main:app --reload
 ```
 
 This also enables the interactive API docs at `/api/docs`.
+
+## Metrics Storage
+
+Metrics are collected by the embedded `eero-prometheus-exporter` and stored in an embedded VictoriaMetrics instance.
+
+- **Collection interval** — `EERO_DASHBOARD_COLLECTION_INTERVAL` sets how often the exporter scrapes the Eero API (default `60` seconds).
+- **Retention** — `EERO_DASHBOARD_METRICS_RETENTION` sets how long VictoriaMetrics keeps the data. Accepted suffixes: `d` (days), `w` (weeks), `m` (months), `y` (years). Examples: `30d`, `6m`, `1y` (default).
+- **Storage size** — There is no hard cap on the number of metrics; old data is dropped only when it exceeds the retention period. Disk usage grows with the number of devices and the collection interval.
+
+### Expose `/metrics` for external Prometheus
+
+If you want to scrape the metrics from your own Prometheus or Grafana setup:
+
+```bash
+EERO_DASHBOARD_METRICS_ENDPOINT_ENABLED=true
+```
+
+This exposes a proxied `/metrics` endpoint on the dashboard's port.


### PR DESCRIPTION
## Summary

- **Bulk profile assignment** — when assigning multiple devices to a profile from the device list, all selected devices are now sent in a single API call instead of issuing per-device requests that overwrote each other and left only the last device assigned (`backend/app/routes/profiles.py`, `frontend/src/lib/stores/devices.ts`, `DeviceList.svelte`).
- **Tests** — added backend (`tests/test_profiles.py`) and frontend store (`stores/devices.test.ts`) coverage for the bulk-assign path, plus MSW handlers.
- **Docs** — `wiki/Configuration.md` now documents every `EERO_DASHBOARD_*` / `EERO_EXPORTER_*` environment variable and adds a Metrics Storage section covering retention format and storage behavior.

## Test plan

- [ ] `cd backend && pytest tests/test_profiles.py`
- [ ] `cd frontend && npm run test -- src/lib/stores/devices.test.ts`
- [ ] Manually: select multiple devices in the device list → assign to a profile → confirm all selected devices appear under that profile (not just the last one)
- [ ] Manually: select multiple devices → assign to "None" → confirm all are detached
- [ ] Skim `wiki/Configuration.md` for typos / table rendering