### PR TITLE
[draft-fix] BUG: speed test graph shows wrong values

### DIFF
--- a/backend/app/routes/metrics.py
+++ b/backend/app/routes/metrics.py
@@ -95,25 +95,32 @@ async def get_speedtest_history(
     start: str = Query(..., description="Start time (RFC3339 or Unix timestamp)"),
     end: str = Query(..., description="End time (RFC3339 or Unix timestamp)"),
     step: str = Query("5m", description="Query resolution step"),
+    network_id: str | None = Query(
+        None, description="Filter results to a specific network"
+    ),
 ) -> dict[str, Any]:
     """Get speedtest history for charts.
 
-    Returns download and upload speeds over time.
+    Returns download and upload speeds over time. When network_id is
+    provided, results are filtered to that network so multi-network
+    accounts don't see another network's series picked arbitrarily.
 
     Args:
         start: Start time for the range.
         end: End time for the range.
         step: Query resolution step.
+        network_id: Optional network ID to filter the metrics by.
 
     Returns:
         Download and upload speed history.
     """
+    selector = f'{{network_id="{network_id}"}}' if network_id else ""
     try:
         download = await victoria_client.query_range(
-            "eero_speed_download_mbps", start, end, step
+            f"eero_speed_download_mbps{selector}", start, end, step
         )
         upload = await victoria_client.query_range(
-            "eero_speed_upload_mbps", start, end, step
+            f"eero_speed_upload_mbps{selector}", start, end, step
         )
         return {"download": download, "upload": upload}
     except httpx.RequestError as e:

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,57 @@
+"""Tests for metrics routes."""
+
+from unittest.mock import AsyncMock, patch
+
+
+class TestSpeedtestHistory:
+    """Tests for GET /api/metrics/speedtest/history."""
+
+    async def test_filters_by_network_id_when_provided(self, auth_client):
+        """PromQL must include the network_id label selector when filtering.
+
+        Multi-network accounts otherwise see an arbitrary network's series
+        because the frontend picks result[0] (see issue #201).
+        """
+        with patch(
+            "app.routes.metrics.victoria_client.query_range",
+            new=AsyncMock(
+                return_value={"status": "success", "data": {"result": []}}
+            ),
+        ) as mock_query:
+            response = await auth_client.get(
+                "/api/metrics/speedtest/history",
+                params={
+                    "start": "2024-01-01T00:00:00Z",
+                    "end": "2024-01-02T00:00:00Z",
+                    "step": "5m",
+                    "network_id": "net-abc",
+                },
+            )
+
+        assert response.status_code == 200
+        assert mock_query.await_count == 2
+        queries = [call.args[0] for call in mock_query.await_args_list]
+        assert 'eero_speed_download_mbps{network_id="net-abc"}' in queries
+        assert 'eero_speed_upload_mbps{network_id="net-abc"}' in queries
+
+    async def test_omits_selector_when_network_id_missing(self, auth_client):
+        """No network_id means no label selector (preserves existing behavior)."""
+        with patch(
+            "app.routes.metrics.victoria_client.query_range",
+            new=AsyncMock(
+                return_value={"status": "success", "data": {"result": []}}
+            ),
+        ) as mock_query:
+            response = await auth_client.get(
+                "/api/metrics/speedtest/history",
+                params={
+                    "start": "2024-01-01T00:00:00Z",
+                    "end": "2024-01-02T00:00:00Z",
+                    "step": "5m",
+                },
+            )
+
+        assert response.status_code == 200
+        queries = [call.args[0] for call in mock_query.await_args_list]
+        assert "eero_speed_download_mbps" in queries
+        assert "eero_speed_upload_mbps" in queries

--- a/frontend/src/lib/api/metrics.ts
+++ b/frontend/src/lib/api/metrics.ts
@@ -78,14 +78,18 @@ async function fetchMetrics<T>(path: string, params: Record<string, string>): Pr
 export async function getSpeedtestHistory(
 	start: string,
 	end: string,
-	step = '5m'
+	step = '5m',
+	networkId?: string
 ): Promise<{ download: TimeSeriesPoint[]; upload: TimeSeriesPoint[] }> {
 	try {
-		const response = await fetchMetrics<SpeedtestHistoryResponse>('/metrics/speedtest/history', {
-			start,
-			end,
-			step
-		});
+		const params: Record<string, string> = { start, end, step };
+		if (networkId) {
+			params.network_id = networkId;
+		}
+		const response = await fetchMetrics<SpeedtestHistoryResponse>(
+			'/metrics/speedtest/history',
+			params
+		);
 
 		return {
 			download: transformMetricsResponse(response.download),

--- a/frontend/src/lib/components/charts/SpeedtestChart.svelte
+++ b/frontend/src/lib/components/charts/SpeedtestChart.svelte
@@ -13,8 +13,7 @@
 		networkId: string;
 	}
 
-	// networkId will be used in future for network-specific filtering
-	let { networkId: _networkId }: Props = $props();
+	let { networkId }: Props = $props();
 
 	let timeRange: '24h' | '7d' | '30d' = $state('24h');
 	let loading = $state(true);
@@ -75,7 +74,12 @@
 			const start = getStartTime(timeRange, now);
 			const step = getStep(timeRange);
 
-			const data = await getSpeedtestHistory(start.toISOString(), now.toISOString(), step);
+			const data = await getSpeedtestHistory(
+				start.toISOString(),
+				now.toISOString(),
+				step,
+				networkId
+			);
 
 			downloadData = data.download;
 			uploadData = data.upload;


### PR DESCRIPTION
Fixes #201

_This is a DRAFT pull request opened by the [Claude Code draft-fix workflow](.github/workflows/draft-fix.yml) in response to the `try-fix` label on #201. The agent (Claude Code via maintainer's Claude Pro/Max OAuth) browsed the repo, identified the bug, made focused changes, and committed. A maintainer should review before anything ships._

## What changed

- `backend/app/routes/metrics.py` — speedtest history endpoint now accepts/applies a `network_id` filter (root cause: history wasn't scoped to the network shown on the dashboard, so multi-network setups saw mixed values).
- `frontend/src/lib/api/metrics.ts` — API client forwards `networkId` to the backend.
- `frontend/src/lib/components/charts/SpeedtestChart.svelte` — Svelte component passes its `networkId` prop through to the API call.
- `backend/tests/test_metrics.py` — new test asserting the `network_id` filter is applied.

## Reviewer notes

- Tests were **not** run by the agent (`--dangerously-skip-permissions` not granted, prompt explicitly defers test execution to the maintainer). Please run `npm test` (frontend) and `pytest` (backend) before merging.
- The fix matches the reporter's hypothesis: "I have another network, and it has 1M/1M fibre service, so I wonder if it may be showing the speedtest values on the graph from that network by mistake?"

[Actions run](https://github.com/fulviofreitas/eero-ui/actions/runs/26554864053)