### PR TITLE
[draft-fix] BUG: does not show accurate 6Ghz usage

### DIFF
--- a/backend/app/transformers.py
+++ b/backend/app/transformers.py
@@ -313,7 +313,13 @@ def normalize_device(raw: dict[str, Any]) -> dict[str, Any]:
         signal_bars = connectivity.get("score_bars")
         frequency_mhz = connectivity.get("frequency")
         if frequency_mhz:
-            frequency = "5GHz" if frequency_mhz > 4000 else "2.4GHz"
+            # 6 GHz band (Wi-Fi 6E) starts at 5925 MHz per FCC.
+            if frequency_mhz >= 5925:
+                frequency = "6GHz"
+            elif frequency_mhz > 4000:
+                frequency = "5GHz"
+            else:
+                frequency = "2.4GHz"
         rx_bitrate = connectivity.get("rx_bitrate")
         tx_bitrate = connectivity.get("tx_bitrate")
 

--- a/backend/tests/test_transformers.py
+++ b/backend/tests/test_transformers.py
@@ -252,6 +252,23 @@ class TestNormalizeDevice:
         assert result["frequency"] == "5GHz"
         assert result["signal_bars"] == 4
 
+    def test_derives_frequency_band_from_mhz(self):
+        """Should bucket frequency_mhz into 2.4GHz / 5GHz / 6GHz bands."""
+        cases = [
+            (2412, "2.4GHz"),
+            (2462, "2.4GHz"),
+            (5200, "5GHz"),
+            (5805, "5GHz"),
+            (5925, "6GHz"),
+            (6175, "6GHz"),
+            (7115, "6GHz"),
+        ]
+        for freq_mhz, expected in cases:
+            raw = {"url": "/devices/1", "connectivity": {"frequency": freq_mhz}}
+            assert normalize_device(raw)["frequency"] == expected, (
+                f"{freq_mhz} MHz should map to {expected}"
+            )
+
     def test_extracts_source_eero(self):
         """Should extract connected eero info from source."""
         raw = {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -202,7 +202,7 @@ export interface DeviceSummary {
 	is_guest: boolean;
 	connection_type: 'wireless' | 'wired' | null;
 	signal_strength: number | null;
-	frequency: '2.4GHz' | '5GHz' | null;
+	frequency: '2.4GHz' | '5GHz' | '6GHz' | null;
 	connected_to_eero: string | null;
 	last_active: string | null;
 	profile_id: string | null;

--- a/frontend/src/lib/components/device/DeviceList.svelte
+++ b/frontend/src/lib/components/device/DeviceList.svelte
@@ -419,6 +419,13 @@
 				>
 					5 GHz ({$deviceCounts.freq5})
 				</button>
+				<button
+					class="filter-btn"
+					class:active={$deviceFilters.frequency === '6GHz'}
+					on:click={() => handleFrequencyFilter('6GHz')}
+				>
+					6 GHz ({$deviceCounts.freq6})
+				</button>
 			</div>
 		</div>
 	</div>

--- a/frontend/src/lib/stores/devices.ts
+++ b/frontend/src/lib/stores/devices.ts
@@ -23,7 +23,7 @@ interface DeviceFilters {
 	search: string;
 	status: 'all' | 'connected' | 'disconnected' | 'blocked';
 	connectionType: 'all' | 'wireless' | 'wired';
-	frequency: 'all' | '2.4GHz' | '5GHz';
+	frequency: 'all' | '2.4GHz' | '5GHz' | '6GHz';
 	sortBy:
 		| 'name'
 		| 'ip'
@@ -479,7 +479,8 @@ export const deviceCounts = derived(devicesStore, ($devices) => {
 		wireless: devices.filter((d) => d.wireless && d.connected).length,
 		wired: devices.filter((d) => !d.wireless && d.connected).length,
 		freq24: devices.filter((d) => d.frequency === '2.4GHz' && d.connected).length,
-		freq5: devices.filter((d) => d.frequency === '5GHz' && d.connected).length
+		freq5: devices.filter((d) => d.frequency === '5GHz' && d.connected).length,
+		freq6: devices.filter((d) => d.frequency === '6GHz' && d.connected).length
 	};
 });
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -69,7 +69,8 @@
 
 	$: wifiBandData = [
 		{ label: '2.4 GHz', value: $deviceCounts.freq24, color: 'rgba(34, 197, 94, 0.8)' },
-		{ label: '5 GHz', value: $deviceCounts.freq5, color: 'rgba(168, 85, 247, 0.8)' }
+		{ label: '5 GHz', value: $deviceCounts.freq5, color: 'rgba(168, 85, 247, 0.8)' },
+		{ label: '6 GHz', value: $deviceCounts.freq6, color: 'rgba(59, 130, 246, 0.8)' }
 	];
 
 	$: clientsPerEeroData = eeros.map((eero, index) => ({


### PR DESCRIPTION
Fixes #202

_This is a DRAFT pull request opened by the [Claude Code draft-fix workflow](.github/workflows/draft-fix.yml) in response to the `try-fix` label on #202. The agent (Claude Code via maintainer's Claude Pro/Max OAuth) browsed the repo, identified the bug, made focused changes, and committed. A maintainer should review before anything ships._

## What changed

- `backend/app/transformers.py` (+7/-1) — transformer logic adjusted to surface 6GHz radio usage
- `backend/tests/test_transformers.py` (+17/-0) — new test for the 6GHz path
- `frontend/src/lib/api/types.ts` (+1/-1) — types refresh
- `frontend/src/lib/components/device/DeviceList.svelte` (+7/-0) — display the 6GHz signal/usage in the device row
- `frontend/src/lib/stores/devices.ts` (+3/-2) — store update
- `frontend/src/routes/+page.svelte` (+2/-1) — page wiring

## Reviewer notes

- Tests were **not** run by the agent (`--dangerously-skip-permissions` not granted; prompt explicitly defers test execution to the maintainer).
- This PR was opened manually after the workflow run pushed the branch successfully but failed at `gh pr create` because `can_approve_pull_request_reviews` was disabled on the repo. That setting has now been enabled, so future runs will auto-open the PR.

[Actions run](https://github.com/fulviofreitas/eero-ui/actions/runs/26555405047)