### PR TITLE
feat(deps): upgrade eero-api to 5.0.0 and eero-prometheus-exporter to 3.18.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "python-multipart>=0.0.18",
     "slowapi>=0.1.9",
     "httpx>=0.28.0",
-    "eero-api==4.2.0",
-    "eero-prometheus-exporter==3.16.2",
+    "eero-api==5.0.0",
+    "eero-prometheus-exporter==3.18.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Upgrades `eero-api` from `4.2.0` → `5.0.0` (major)
- Upgrades `eero-prometheus-exporter` from `3.16.2` → `3.18.0`
- Supersedes and closes both Renovate PRs: #241 and #256

## Breaking change analysis

eero-api v5.0.0 removes `EeroAPI.set_preferred_network()` and `EeroAPI.preferred_network_id` (deprecated since v4.7.0). **No code changes are required** because this codebase already uses `EeroClient` (not `EeroAPI`) for those calls:
- `deps.py` — `client.preferred_network_id` → `EeroClient` ✓
- `auth.py` — `client.preferred_network_id` → `EeroClient` ✓
- `networks.py` — `client.set_preferred_network(network_id)` → `EeroClient` ✓

## Test plan

- [x] All 171 backend tests pass (`pytest`) with eero-api 5.0.0
- [x] `ruff check` passes with no issues

Closes #241
Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated backend Python dependency versions for the core API and monitoring/exporting components to the latest compatible releases, improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->