### PR TITLE
fix(deps): downgrade cookie override to ^0.7.0 for SvelteKit compatibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1123,6 +1123,16 @@
 				}
 			}
 		},
+		"node_modules/@sveltejs/kit/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/@sveltejs/load-config": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
@@ -1286,7 +1296,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/d3-color": {},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2119,20 +2128,6 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/cookie": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
-			"integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=22"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3482,6 +3477,16 @@
 			"integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/msw/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/mute-stream": {
 			"version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
 		"test:coverage": "svelte-kit sync && vitest run --coverage"
 	},
 	"overrides": {
-		"cookie": "^2.0.0",
+		"cookie": "^0.7.0",
 		"esbuild": "^0.28.0"
 	},
 	"devDependencies": {

--- a/frontend/src/lib/components/common/StatusBadge.svelte
+++ b/frontend/src/lib/components/common/StatusBadge.svelte
@@ -5,14 +5,7 @@
 -->
 <script lang="ts">
 	export let status:
-		| 'online'
-		| 'offline'
-		| 'connected'
-		| 'disconnected'
-		| 'blocked'
-		| 'paused'
-		| 'warning'
-		| string;
+		'online' | 'offline' | 'connected' | 'disconnected' | 'blocked' | 'paused' | 'warning' | string;
 	export let showDot: boolean = true;
 	export let size: 'sm' | 'md' = 'md';
 


### PR DESCRIPTION
Renovate bumped the `cookie` override to `^2.0.0` (v2 renamed `parse` → `parseCookie`), which broke the Docker build since `@sveltejs/kit` still requires `cookie ^0.6.0` and uses the old `parse` API internally.

Downgrades the override to `^0.7.0`, which keeps the security fix (out-of-bounds character rejection) while preserving the `parse`/`serialize` API that SvelteKit depends on.

This is the final blocker before CI goes green and the `v5.0.0` release can be published.