### PR TITLE
fix(deps): regenerate lockfile to fix missing @types/d3-color entry

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1296,6 +1296,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",


### PR DESCRIPTION
The lockfile went out of sync when the `cookie` override was changed from `^2.0.0` to `^0.7.0`, leaving `@types/d3-color@3.1.3` absent. This caused `npm ci` to fail immediately in CI with `EUSAGE: package.json and package-lock.json are not in sync`.

Regenerated the lockfile with `npm install` — `npm ci`, lint, type-check, and build all pass locally.