### PR TITLE
feat(deps): bump eero-api to ^6.0.0 and eero-prometheus-exporter to ^3.18.7

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "python-multipart>=0.0.18",
     "slowapi>=0.1.9",
     "httpx>=0.28.0",
-    "eero-api==5.0.0",
-    "eero-prometheus-exporter==3.18.3",
+    "eero-api>=6.0.0,<7.0.0",
+    "eero-prometheus-exporter>=3.18.7,<4.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Coordinated bump of the two eero backend deps:

| Package | Before | After |
|---|---|---|
| `eero-api` | `==5.0.0` | `>=6.0.0,<7.0.0` |
| `eero-prometheus-exporter` | `==3.18.3` | `>=3.18.7,<4.0.0` |

The exporter is bumped alongside because its own `pyproject.toml` already requires `eero-api>=6.0.0` — keeping the old exporter pin would create a resolver conflict.

## Supersedes

Closes both stale Renovate PRs, which propose incomplete/conflicting versions of this change:

- **Closes #341** (`feat(deps): update eero packages to 6.0.0`) — bumps `eero-api` to `==6.0.0` but leaves the exporter at `==3.18.3`, which is incompatible with `eero-api>=6.0.0`.
- **Closes #331** (`feat(deps): update eero-packages`) — earlier Renovate PR bumping to `5.0.13` + `3.18.7`; superseded by the 6.0.0 wave.

## Why this is safe

Backend call-site audit — grep across `backend/**/*.py` for every SDK surface affected between 5.0.0 and 6.0.0:

| SDK surface | Change | Call sites in eero-ui |
|---|---|---|
| `get_insights(network_id)` | v6.0.0 breaking signature (required query params added) | **0** |
| `ActivityAPI` / `get_activity` | v6.0.0 breaking removal | **0** |
| `set_device_priority` | v5.0.13 deprecated | **0** (routes removed in #342) |
| `add_to_blacklist` / `remove_from_blacklist` | v5.0.13 payload fixed | **0** |
| `block_device` | v5.0.13 now routes through `/blacklist` | **2** (`devices.py:317`, `:345`) — 🟢 **starts actually working** |

The only affected method we call is `block_device`. Both `POST /api/devices/{id}/block` and `/unblock` currently issue silent no-ops against the real Eero backend on the pinned `5.0.0`; after this bump they'll actually block/unblock devices.

`requires-python = ">=3.12"` already satisfied (backend was bumped in 5.2.3).

## Why the loose upper bound

The previous `eero-api==5.0.0` hard-pin let the SDK drift 13 patch releases and 1 major without any bump PR landing, which is how the dead `prioritize`/`deprioritize` routes (fixed by #338 / #342) went unnoticed. A `>=X,<X+1` range lets Renovate keep us current within a semver-major without one manual PR per patch, while still blocking silent breaking-change bumps.

## Test plan

- [ ] CI: Backend Tests (173 tests), Backend Lint, Docker Build Test
- [ ] Post-merge behaviour (needs a live Eero session):
    - `curl -X POST /api/devices/{id}/block` → device actually blocked on Eero cloud
    - `curl -X POST /api/devices/{id}/unblock` → device actually unblocked
