### PR TITLE
chore(renovate): cap cookie at &lt;2.0.0 until SvelteKit supports v2

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -129,6 +129,25 @@
     },
 
     // ==========================================================================
+    // 🔒 cookie: cap at <2.0.0 until SvelteKit supports cookie 2.x
+    // ==========================================================================
+    // cookie 2.0.0 is ESM-only and renamed `parse`/`serialize` to
+    // `parseCookie`/`stringifySetCookie`. SvelteKit's adapter still emits
+    // `import { parse, serialize } from "cookie"`, so the prod build fails
+    // (see PR #320 → reverted in #344). SvelteKit 2.70.1 (latest as of
+    // 2026-07-24) still transitively declares cookie ^0.6.0.
+    //
+    // We keep the override at ^1.0.2 (CVE-2024-47764 safe, SvelteKit-compat).
+    // Revisit when SvelteKit ships a release that consumes cookie 2.x.
+    {
+      matchPackageNames: ["cookie"],
+      matchManagers: ["npm"],
+      allowedVersions: "<2.0.0",
+      description: "Block cookie 2.x — SvelteKit adapter still uses removed named exports",
+      addLabels: ["blocked-upstream"],
+    },
+
+    // ==========================================================================
     // 🟢 eero-packages - Internal dependencies (GROUPED to resolve conflicts)
     // ==========================================================================
     // eero-prometheus-exporter depends on eero-api, so they MUST be updated


### PR DESCRIPTION
## Summary

Prevents Renovate from re-proposing the broken `cookie 2.x` bump that #320 landed and #344 reverted.

`cookie 2.0.0` is ESM-only and removed the deprecated named exports `parse` / `serialize` in favor of `parseCookie` / `stringifySetCookie`, but SvelteKit's adapter still emits `import { parse, serialize } from "cookie"` — the prod build fails with `SyntaxError: The requested module 'cookie' does not provide an export named 'parse'`.

Latest SvelteKit (2.70.1, confirmed via `npm view @sveltejs/kit@latest dependencies.cookie`) still transitively pins `cookie: ^0.6.0`. No upstream fix exists to bump to yet.

## Change

Single-file, 19-line addition to `.github/renovate.json5` — a `packageRule` for `cookie` with `allowedVersions: "<2.0.0"` and an inline comment explaining the constraint chain and the exit criterion.

The existing `overrides: { "cookie": "^1.0.2" }` in `frontend/package.json` (added in `51abdf4` for CVE-2024-47764) stays as-is — it's the CVE-safe, SvelteKit-compatible sweet spot.

## Full constraint chain

- `cookie ≥ 0.7.0` — CVE-2024-47764 (GHSA-pxg6-pf52-xh8x) patched here
- `cookie < 2.0.0` — SvelteKit adapter incompatibility (this PR)
- Current install: `cookie@1.1.1` ✅

## Follow-up

Tracked in a separate issue: remove this rule (and the override) when SvelteKit ships a release that consumes `cookie 2.x`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automatic updates of the `cookie` package to versions below 2.0.0.
  * Added tracking metadata and documentation for the version restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->